### PR TITLE
Question answering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+### Fixed
+- Fixed bug with question answering benchmarking when the answer was a proper subset of
+  the first token in the context, causing errors when benchmarking some models.
+
+
 ## [v8.1.0] - 2023-12-04
 ### Added
 - Now added support for text-to-text tasks, which include tasks such as abstractive

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -420,9 +420,13 @@ def prepare_train_examples(
                 ):
                     token_start_index += 1
                 tokenized_examples.start_positions.append(token_start_index - 1)
-                while token_end_index > 0 and offsets[token_end_index][1] >= end_char:
+                while (
+                    token_end_index > token_start_index
+                    and offsets[token_end_index][1] >= end_char
+                ):
                     token_end_index -= 1
                 tokenized_examples.end_positions.append(token_end_index + 1)
+                assert token_end_index >= token_start_index
 
     return tokenized_examples
 

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -420,7 +420,7 @@ def prepare_train_examples(
                 ):
                     token_start_index += 1
                 tokenized_examples.start_positions.append(token_start_index - 1)
-                while offsets[token_end_index][1] >= end_char:
+                while token_end_index > 0 and offsets[token_end_index][1] >= end_char:
                     token_end_index -= 1
                 tokenized_examples.end_positions.append(token_end_index + 1)
 

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -419,13 +419,15 @@ def prepare_train_examples(
                     and offsets[token_start_index][0] <= start_char
                 ):
                     token_start_index += 1
-                tokenized_examples.start_positions.append(token_start_index - 1)
+                token_start_index -= 1
+                tokenized_examples.start_positions.append(token_start_index)
                 while (
-                    token_end_index >= token_start_index
+                    token_start_index <= token_end_index
                     and offsets[token_end_index][1] >= end_char
                 ):
                     token_end_index -= 1
-                tokenized_examples.end_positions.append(token_end_index + 1)
+                token_end_index += 1
+                tokenized_examples.end_positions.append(token_end_index)
                 assert token_end_index >= token_start_index
 
     return tokenized_examples

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -415,13 +415,13 @@ def prepare_train_examples(
             # the last word (edge case).
             else:
                 while (
-                    token_start_index < len(offsets)
+                    token_start_index <= token_end_index
                     and offsets[token_start_index][0] <= start_char
                 ):
                     token_start_index += 1
                 tokenized_examples.start_positions.append(token_start_index - 1)
                 while (
-                    token_end_index > token_start_index
+                    token_end_index >= token_start_index
                     and offsets[token_end_index][1] >= end_char
                 ):
                     token_end_index -= 1

--- a/tests/test_question_answering.py
+++ b/tests/test_question_answering.py
@@ -1,13 +1,15 @@
 """Unit tests for the `question_answering` module."""
 
 import pytest
+from contextlib import nullcontext as does_not_raise
 
+from transformers import AutoTokenizer
 from scandeval.dataset_configs import (
     SCANDIQA_DA_CONFIG,
     SCANDIQA_NO_CONFIG,
     SCANDIQA_SV_CONFIG,
 )
-from scandeval.question_answering import QuestionAnswering
+from scandeval.question_answering import QuestionAnswering, prepare_train_examples
 
 
 @pytest.mark.parametrize(
@@ -42,3 +44,41 @@ class TestScores:
         min_score = scores["test_f1"] - scores["test_f1_se"]
         max_score = scores["test_f1"] + scores["test_f1_se"]
         assert min_score <= correct_scores[1] <= max_score
+
+
+@pytest.mark.parametrize(
+    argnames="tokenizer_model_id",
+    argvalues=[
+        "jonfd/electra-small-nordic",
+        "flax-community/swe-roberta-wiki-oscar",
+    ],
+)
+@pytest.mark.parametrize(
+    argnames="examples",
+    argvalues=[
+        dict(
+            question=["Hvad er hovedstaden i Sverige?"],
+            context=["Sveriges hovedstad er Stockholm."],
+            answers=[dict(text=["Stockholm"], answer_start=[22])],
+        ),
+        dict(
+            question=["Hvad er hovedstaden i Sverige?"],
+            context=["Sveriges hovedstad er Stockholm." * 100],
+            answers=[dict(text=["Sverige"], answer_start=[0])],
+        ),
+        dict(
+            question=["Hvad er hovedstaden i Danmark?"],
+            context=["Danmarks hovedstad er København. " * 100],
+            answers=[dict(text=["Da"], answer_start=[0])],
+        ),
+    ],
+)
+def test_prepare_train_examples(examples, tokenizer_model_id):
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_model_id)
+    if (
+        hasattr(tokenizer, "model_max_length")
+        and tokenizer.model_max_length > 100_000_000
+    ):
+        tokenizer.model_max_length = 512
+    with does_not_raise():
+        prepare_train_examples(examples=examples, tokenizer=tokenizer)


### PR DESCRIPTION
This fixes a bug causing an error when benchmarking some models on question answering datasets.

The error occurs when the answer is a proper subset of the first token in the context, and is fixed by simply using the entire first token when this occurs.