### PR TITLE
Layernorm and fp16 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Some models use an implementation of layer normalisation which is incompatible with
+  mixed precision (fp16), preventing benchmarking. When running these models, fp16 will
+  now be disabled.
+
+
 ## [v8.1.0] - 2023-12-04
 ### Added
 - Now added support for text-to-text tasks, which include tasks such as abstractive

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -240,7 +240,7 @@ class Benchmarker:
                     logger.info(
                         f"{m_id} could not be benchmarked on "
                         f"{dataset_config.pretty_name}. Skipping. The error message "
-                        f"raise dwas {error_msg!r}."
+                        f"raised was {error_msg!r}."
                     )
                     continue
 

--- a/src/scandeval/finetuning.py
+++ b/src/scandeval/finetuning.py
@@ -100,6 +100,7 @@ def finetune(
     scores: dict[str, list[dict[str, float]]] = defaultdict(list)
 
     bs: int = benchmark_config.batch_size
+    use_fp16 = benchmark_config.device == torch.device("cuda")
     for idx in itr:
         # Set variable that tracks whether we need to initialize new models in
         # the single iteration call
@@ -133,6 +134,7 @@ def finetune(
                     benchmark_config=benchmark_config,
                     model_config=model_config,
                     iteration_idx=idx,
+                    use_fp16=use_fp16,
                     batch_size=bs,
                 )
 
@@ -165,6 +167,11 @@ def finetune(
                 logger.debug(f"Test scores for iteration {idx}: {itr_scores['test']}")
 
                 break
+
+            except RuntimeError as e:
+                if "\"LayerNormKernelImpl\" not implemented for 'Half'" not in str(e):
+                    raise InvalidBenchmark(str(e))
+                use_fp16 = False
 
             except Exception as e:
                 if "CUDA" not in str(e) and "out of memory" not in str(e):
@@ -333,6 +340,7 @@ def get_training_args(
     benchmark_config: BenchmarkConfig,
     model_config: ModelConfig,
     iteration_idx: int,
+    use_fp16: bool,
     batch_size: int | None = None,
 ) -> TrainingArguments:
     """Get the training arguments for the current iteration.
@@ -391,7 +399,7 @@ def get_training_args(
             load_best_model_at_end=True,
             optim=optimizer,
             seed=seed,
-            fp16=benchmark_config.device == torch.device("cuda"),
+            fp16=use_fp16,
             disable_tqdm=not benchmark_config.progress_bar,
             ddp_find_unused_parameters=False,
         )

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -246,7 +246,7 @@ class HFModelSetup:
             cache_dir=model_config.model_cache_dir,
             trust_remote_code=self.benchmark_config.trust_remote_code,
             quantization_config=bnb_config,
-            torch_dtype="auto",
+            torch_dtype=None if config.to_dict().get("torch_dtype") is None else "auto",
             use_flash_attention_2=use_flash_attention,
         )
 

--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `finetuning` module."""

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `generation` module."""

--- a/tests/test_model_setups/test_fresh.py
+++ b/tests/test_model_setups/test_fresh.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `model_setups.fresh` module."""

--- a/tests/test_model_setups/test_hf.py
+++ b/tests/test_model_setups/test_hf.py
@@ -1,0 +1,31 @@
+"""Unit tests for the `model_setups.hf` module."""
+
+import pytest
+import torch
+from scandeval.model_setups.hf import HFModelSetup
+
+
+@pytest.mark.parametrize(
+    argnames=["model_id", "expected"],
+    argvalues=[
+        ("microsoft/mdeberta-v3-base", None),
+        ("jonfd/electra-small-nordic", None),
+        ("mistralai/Mistral-7B-v0.1", torch.bfloat16),
+    ],
+    ids=[
+        "mdeberta-v3-base",
+        "electra-small-nordic",
+        "mistral-7b",
+    ],
+)
+def test_torch_dtype_is_set_correctly(benchmark_config, model_id, expected):
+    model_setup = HFModelSetup(benchmark_config=benchmark_config)
+    hf_model_config = model_setup._load_hf_model_config(
+        model_id=model_id,
+        num_labels=0,
+        id2label=dict(),
+        label2id=dict(),
+        revision="main",
+        model_cache_dir=benchmark_config.cache_dir,
+    )
+    assert hf_model_config.torch_dtype == expected

--- a/tests/test_model_setups/test_local.py
+++ b/tests/test_model_setups/test_local.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `model_setups.local` module."""

--- a/tests/test_model_setups/test_openai.py
+++ b/tests/test_model_setups/test_openai.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `model_setups.openai` module."""

--- a/tests/test_model_setups/test_utils.py
+++ b/tests/test_model_setups/test_utils.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `model_setups.utils` module."""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `protocols` module."""

--- a/tests/test_text_to_text.py
+++ b/tests/test_text_to_text.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `text_to_text` module."""


### PR DESCRIPTION
This fixes a bug where a few models encountered an error when benchmarking them on CUDA, due to their layernorm implementation not supporting fp16.

The error happens since `torch_dtype` is set when loading the model based on *either* the HuggingFace model configuration, if it has been specified in there, or the data type of the first weight of the model. The `torch_dtype` is then the data type that the model will be loaded in as. This is completely fine in the cases where `torch_dtype` is set in the model configuration, such as with the Mistral model, but we encounter the above issue when this is not set in the model configuration and the model has been stored in mixed precision.

The fix is simply to check if `torch_dtype` is set in the model configuration, and only setting it to "auto" during model initialisation if this is the case - otherwise we set it to None, which defaults to loading in float32.

Added a unit test to check for this.