### PR TITLE
feat: Add English datasets

### DIFF
--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -366,7 +366,7 @@ CONLL_EN_CONFIG = DatasetConfig(
     pretty_name="the truncated version of CoNLL 2003",
     huggingface_id="ScandEval/conll-en-mini",
     task=NER,
-    languages=[NL],
+    languages=[EN],
     prompt_prefix="Below are sentences and JSON dictionaries with the named "
     "entities that occur in the given sentence.",
     prompt_template="Sentence: {text}\nNamed entities: {label}",

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -2,7 +2,7 @@
 
 from .config import DatasetConfig
 from .dataset_tasks import LA, NER, QA, SENT, SPEED, SUMMARIZATION
-from .languages import DA, DE, FO, IS, NB, NL, NN, SV, get_all_languages
+from .languages import DA, DE, EN, FO, IS, NB, NL, NN, SV, get_all_languages
 
 
 def get_all_dataset_configs() -> dict[str, DatasetConfig]:
@@ -59,7 +59,6 @@ SWEREC_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 ANGRY_TWEETS_CONFIG = DatasetConfig(
     name="angry-tweets",
     pretty_name="the truncated version of AngryTweets",
@@ -75,7 +74,6 @@ ANGRY_TWEETS_CONFIG = DatasetConfig(
     num_few_shot_examples=12,
     max_generated_tokens=3,
 )
-
 
 NOREC_CONFIG = DatasetConfig(
     name="norec",
@@ -93,7 +91,6 @@ NOREC_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 ISREC_CONFIG = DatasetConfig(
     name="isrec",
     pretty_name="the truncated version of IsReC",
@@ -109,7 +106,6 @@ ISREC_CONFIG = DatasetConfig(
     num_few_shot_examples=12,
     max_generated_tokens=3,
 )
-
 
 FOREC_CONFIG = DatasetConfig(
     name="forec",
@@ -127,7 +123,6 @@ FOREC_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 SB10K_CONFIG = DatasetConfig(
     name="sb10k",
     pretty_name="the truncated version of SB10k",
@@ -144,7 +139,6 @@ SB10K_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 DUTCH_SOCIAL_CONFIG = DatasetConfig(
     name="dutch-social",
     pretty_name="the truncated version of Dutch Social",
@@ -160,6 +154,25 @@ DUTCH_SOCIAL_CONFIG = DatasetConfig(
     num_few_shot_examples=12,
     max_generated_tokens=3,
 )
+
+SST5_CONFIG = DatasetConfig(
+    name="sst5",
+    pretty_name="the truncated version of SST5",
+    huggingface_id="ScandEval/sst5-mini",
+    task=SENT,
+    languages=[EN],
+    prompt_prefix="The following are tweets are their sentiment, which can be "
+    "'positive', 'neutral' or 'negative'.",
+    prompt_template="Tweet: {text}\nSentiment: {label}",
+    prompt_label_mapping=dict(
+        positive="positive", neutral="neutral", negative="negative"
+    ),
+    num_few_shot_examples=12,
+    max_generated_tokens=3,
+)
+
+# TODO: Icelandic Sentiment Classification
+# TODO: Faroese Sentiment Classification
 
 
 ### NAMED ENTITY RECOGNITION DATASETS ###
@@ -187,7 +200,6 @@ SUC3_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 DANE_CONFIG = DatasetConfig(
     name="dane",
     pretty_name="the truncated version of DaNE",
@@ -210,7 +222,6 @@ DANE_CONFIG = DatasetConfig(
     num_few_shot_examples=8,
     max_generated_tokens=128,
 )
-
 
 NORNE_NB_CONFIG = DatasetConfig(
     name="norne-nb",
@@ -235,7 +246,6 @@ NORNE_NB_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 NORNE_NN_CONFIG = DatasetConfig(
     name="norne-nn",
     pretty_name="the truncated version of the Nynorsk part of NorNE",
@@ -258,7 +268,6 @@ NORNE_NN_CONFIG = DatasetConfig(
     num_few_shot_examples=8,
     max_generated_tokens=128,
 )
-
 
 MIM_GOLD_NER_CONFIG = DatasetConfig(
     name="mim-gold-ner",
@@ -283,7 +292,6 @@ MIM_GOLD_NER_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 WIKIANN_FO_CONFIG = DatasetConfig(
     name="wikiann-fo",
     pretty_name="the truncated version of the Faroese part of WikiANN",
@@ -306,7 +314,6 @@ WIKIANN_FO_CONFIG = DatasetConfig(
     num_few_shot_examples=8,
     max_generated_tokens=128,
 )
-
 
 GERMEVAL_CONFIG = DatasetConfig(
     name="germeval",
@@ -331,7 +338,6 @@ GERMEVAL_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 CONLL_NL_CONFIG = DatasetConfig(
     name="conll-nl",
     pretty_name="the Dutch part of the truncated version of CoNLL 2002",
@@ -355,6 +361,29 @@ CONLL_NL_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
+CONLL_EN_CONFIG = DatasetConfig(
+    name="conll-en",
+    pretty_name="the truncated version of CoNLL 2003",
+    huggingface_id="ScandEval/conll-en-mini",
+    task=NER,
+    languages=[NL],
+    prompt_prefix="Below are sentences and JSON dictionaries with the named "
+    "entities that occur in the given sentence.",
+    prompt_template="Sentence: {text}\nNamed entities: {label}",
+    prompt_label_mapping={
+        "b-per": "person",
+        "i-per": "person",
+        "b-loc": "location",
+        "i-loc": "location",
+        "b-org": "organization",
+        "i-org": "organization",
+        "b-misc": "miscellaneous",
+        "i-misc": "miscellaneous",
+    },
+    num_few_shot_examples=8,
+    max_generated_tokens=128,
+)
+
 
 ### LINGUISTIC ACCEPTABILITY DATASETS ###
 
@@ -371,7 +400,6 @@ SCALA_SV_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 SCALA_DA_CONFIG = DatasetConfig(
     name="scala-da",
     pretty_name="the Danish part of ScaLA",
@@ -384,7 +412,6 @@ SCALA_DA_CONFIG = DatasetConfig(
     num_few_shot_examples=12,
     max_generated_tokens=3,
 )
-
 
 SCALA_NB_CONFIG = DatasetConfig(
     name="scala-nb",
@@ -399,7 +426,6 @@ SCALA_NB_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-
 SCALA_NN_CONFIG = DatasetConfig(
     name="scala-nn",
     pretty_name="the Nynorsk part of ScaLA",
@@ -412,7 +438,6 @@ SCALA_NN_CONFIG = DatasetConfig(
     num_few_shot_examples=12,
     max_generated_tokens=3,
 )
-
 
 SCALA_IS_CONFIG = DatasetConfig(
     name="scala-is",
@@ -467,6 +492,19 @@ SCALA_NL_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
+SCALA_EN_CONFIG = DatasetConfig(
+    name="scala-en",
+    pretty_name="the English part of ScaLA",
+    huggingface_id="ScandEval/scala-en",
+    task=LA,
+    languages=[EN],
+    prompt_prefix="The following are sentences and whether they are grammatically correct.",
+    prompt_template="Sentence: {text}\nGrammatically correct: {label}",
+    prompt_label_mapping=dict(correct="yes", incorrect="no"),
+    num_few_shot_examples=12,
+    max_generated_tokens=3,
+)
+
 
 ### EXTRACTIVE QUESTION ANSWERING DATASETS ###
 
@@ -481,7 +519,6 @@ SCANDIQA_DA_CONFIG = DatasetConfig(
     max_generated_tokens=32,
 )
 
-
 SCANDIQA_NO_CONFIG = DatasetConfig(
     name="scandiqa-no",
     pretty_name="the Norwegian part of truncated version of ScandiQA",
@@ -493,7 +530,6 @@ SCANDIQA_NO_CONFIG = DatasetConfig(
     max_generated_tokens=32,
 )
 
-
 SCANDIQA_SV_CONFIG = DatasetConfig(
     name="scandiqa-sv",
     pretty_name="the Swedish part of the truncated version of ScandiQA",
@@ -504,7 +540,6 @@ SCANDIQA_SV_CONFIG = DatasetConfig(
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
-
 
 NQII_CONFIG = DatasetConfig(
     name="nqii",
@@ -518,7 +553,6 @@ NQII_CONFIG = DatasetConfig(
     max_generated_tokens=32,
 )
 
-
 FOQA_CONFIG = DatasetConfig(
     name="foqa",
     pretty_name="Faroese Question Answering",
@@ -530,7 +564,6 @@ FOQA_CONFIG = DatasetConfig(
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
-
 
 GERMANQUAD_CONFIG = DatasetConfig(
     name="germanquad",
@@ -544,8 +577,17 @@ GERMANQUAD_CONFIG = DatasetConfig(
     max_generated_tokens=32,
 )
 
+SQUAD_CONFIG = DatasetConfig(
+    name="squad",
+    pretty_name="SQuAD",
+    huggingface_id="ScandEval/squad-mini",
+    task=QA,
+    languages=[EN],
+    prompt_template="{text}\nQuestion: {question}\nAnswer in max 3 words: {label}",
+    num_few_shot_examples=4,
+    max_generated_tokens=32,
+)
 
-# TODO: Icelandic Question Answering
 # TODO: Faroese Question Answering
 # TODO: Dutch Question Answering
 
@@ -563,7 +605,6 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 MLSUM_CONFIG = DatasetConfig(
     name="mlsum",
     pretty_name="the truncated version of MLSum",
@@ -574,7 +615,6 @@ MLSUM_CONFIG = DatasetConfig(
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
-
 
 RRN_CONFIG = DatasetConfig(
     name="rrn",
@@ -587,7 +627,6 @@ RRN_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 NO_SAMMENDRAG_CONFIG = DatasetConfig(
     name="no-sammendrag",
     pretty_name="the truncated version of the Norwegian Sammendrag dataset",
@@ -598,7 +637,6 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
-
 
 WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     name="wiki-lingua-nl",
@@ -611,7 +649,6 @@ WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-
 SWEDN_CONFIG = DatasetConfig(
     name="swedn",
     pretty_name="the truncated version of SweDN",
@@ -619,6 +656,17 @@ SWEDN_CONFIG = DatasetConfig(
     task=SUMMARIZATION,
     languages=[SV],
     prompt_template="{text}\nSammanfattning: {target_text}",
+    num_few_shot_examples=2,
+    max_generated_tokens=128,
+)
+
+CNN_DAILYMAIL_CONFIG = DatasetConfig(
+    name="cnn-dailymail",
+    pretty_name="the truncated version of CNN-DailyMail",
+    huggingface_id="ScandEval/cnn-dailymail-mini",
+    task=SUMMARIZATION,
+    languages=[EN],
+    prompt_template="{text}\nSummary: {target_text}",
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )

--- a/src/scripts/create_cnn_dailymail.py
+++ b/src/scripts/create_cnn_dailymail.py
@@ -1,0 +1,65 @@
+"""Create the CNN-DailyMail-mini summarisation dataset."""
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main():
+    """Create the CNN-DailyMail-mini summarisation dataset and upload to HF Hub."""
+
+    dataset_id = "cnn_dailymail"
+
+    dataset = load_dataset(dataset_id, "3.0.0", token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    dataset = dataset.rename_columns(
+        column_mapping=dict(article="text", highlights="target_text")
+    )
+
+    train_df = dataset["train"].to_pandas()
+    val_df = dataset["validation"].to_pandas()
+    test_df = dataset["test"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(val_df, pd.DataFrame)
+    assert isinstance(test_df, pd.DataFrame)
+
+    # Create validation split
+    val_size = 256
+    val_df = val_df.sample(n=val_size, random_state=4242)
+    val_df = val_df.reset_index(drop=True)
+
+    # Create test split
+    test_size = 2048
+    test_df = test_df.sample(n=test_size, random_state=4242)
+    test_df = test_df.reset_index(drop=True)
+
+    # Create train split
+    train_size = 1024
+    train_df = train_df.sample(n=train_size, random_state=4242)
+    train_df = train_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Create dataset ID
+    mini_dataset_id = "ScandEval/cnn-dailymail-mini"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api: HfApi = HfApi()
+        api.delete_repo(mini_dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(mini_dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_conll_en.py
+++ b/src/scripts/create_conll_en.py
@@ -1,0 +1,106 @@
+"""Create the CoNLL-EN-mini NER dataset and upload it to the HF Hub."""
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main():
+    """Create the CoNLL-EN-mini NER dataset and uploads it to the HF Hub."""
+
+    # Define dataset ID
+    repo_id = "conll2003"
+
+    # Download the dataset
+    dataset = load_dataset(path=repo_id, token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    # Convert the dataset to a dataframe
+    train_df = dataset["train"].to_pandas()
+    val_df = dataset["validation"].to_pandas()
+    test_df = dataset["test"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(val_df, pd.DataFrame)
+    assert isinstance(test_df, pd.DataFrame)
+
+    # Drop all columns except for `tokens` and `ner_tags`
+    columns_to_drop = [
+        col for col in train_df.columns if col not in ["tokens", "ner_tags"]
+    ]
+    train_df.drop(columns=columns_to_drop, inplace=True)
+    val_df.drop(columns=columns_to_drop, inplace=True)
+    test_df.drop(columns=columns_to_drop, inplace=True)
+
+    # Add a `text` column
+    train_df["text"] = train_df["tokens"].map(lambda tokens: " ".join(tokens))
+    val_df["text"] = val_df["tokens"].map(lambda tokens: " ".join(tokens))
+    test_df["text"] = test_df["tokens"].map(lambda tokens: " ".join(tokens))
+
+    # Rename `ner_tags` to `labels`
+    train_df.rename(columns={"ner_tags": "labels"}, inplace=True)
+    val_df.rename(columns={"ner_tags": "labels"}, inplace=True)
+    test_df.rename(columns={"ner_tags": "labels"}, inplace=True)
+
+    # Convert the NER tags from IDs to strings
+    ner_conversion_dict = {
+        0: "O",
+        1: "B-PER",
+        2: "I-PER",
+        3: "B-ORG",
+        4: "I-ORG",
+        5: "B-LOC",
+        6: "I-LOC",
+        7: "B-MISC",
+        8: "I-MISC",
+    }
+    train_df["labels"] = train_df["labels"].map(
+        lambda ner_tags: [ner_conversion_dict[ner_tag] for ner_tag in ner_tags]
+    )
+    val_df["labels"] = val_df["labels"].map(
+        lambda ner_tags: [ner_conversion_dict[ner_tag] for ner_tag in ner_tags]
+    )
+    test_df["labels"] = test_df["labels"].map(
+        lambda ner_tags: [ner_conversion_dict[ner_tag] for ner_tag in ner_tags]
+    )
+
+    # Create validation split
+    val_size = 256
+    val_df = val_df.sample(n=val_size, random_state=4242)
+
+    # Create test split
+    test_size = 2048
+    test_df = test_df.sample(n=test_size, random_state=4242)
+
+    # Create train split
+    train_size = 1024
+    train_df = train_df.sample(n=train_size, random_state=4242)
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split="train"),
+        val=Dataset.from_pandas(val_df, split="val"),
+        test=Dataset.from_pandas(test_df, split="test"),
+    )
+
+    # Create dataset ID
+    dataset_id = "ScandEval/conll-en-mini"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api = HfApi()
+        api.delete_repo(dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_scala.py
+++ b/src/scripts/create_scala.py
@@ -12,6 +12,7 @@ from huggingface_hub.hf_api import HfApi
 from load_ud_pos import (
     load_dadt_pos,
     load_dedt_pos,
+    load_endt_pos,
     load_fodt_pos,
     load_isdt_pos,
     load_nldt_pos,
@@ -41,6 +42,7 @@ def main():
         "fo": load_fodt_pos,
         "de": load_dedt_pos,
         "nl": load_nldt_pos,
+        "en": load_endt_pos,
     }
 
     # Set up the progress bar and iterate over the languages

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -1,0 +1,79 @@
+"""Create the SQuAD-mini datasets and upload them to the HF Hub."""
+
+import pandas as pd
+from datasets.arrow_dataset import Dataset
+from datasets.dataset_dict import DatasetDict
+from datasets.load import load_dataset
+from datasets.splits import Split
+from huggingface_hub.hf_api import HfApi
+from requests.exceptions import HTTPError
+
+
+def main() -> None:
+    """Create the SQuAD-mini datasets and upload them to the HF Hub."""
+
+    dataset_id = "squad_v2"
+
+    # Load the dataset
+    dataset = load_dataset(dataset_id, token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    # Convert the dataset to a dataframe
+    train_df = dataset["train"].to_pandas()
+    valtest_df = dataset["validation"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(valtest_df, pd.DataFrame)
+
+    # Extract information on which examples contain an answer
+    def has_answer(example: dict) -> bool:
+        return len(example["text"]) > 0 and example["text"][0] != ""
+
+    train_has_answer: pd.Series = train_df.answers.map(has_answer)
+    valtest_has_answer: pd.Series = valtest_df.answers.map(has_answer)
+
+    # Only work with the questions having answers in the context
+    train_df_with_answer: pd.DataFrame = train_df.loc[train_has_answer]
+    valtest_df_with_answer: pd.DataFrame = valtest_df.loc[valtest_has_answer]
+
+    # Create validation split
+    val_size = 256
+    val_df = valtest_df_with_answer.sample(n=val_size, random_state=4242)
+
+    # Create test split
+    test_size = 2048
+    valtest_df_with_answer_filtered: pd.DataFrame = valtest_df_with_answer.loc[
+        ~valtest_df_with_answer.index.isin(val_df.index)
+    ]
+    test_df = valtest_df_with_answer_filtered.sample(n=test_size, random_state=4242)
+
+    # Create train split
+    train_size = 1024
+    train_df = train_df_with_answer.sample(n=train_size, random_state=4242)
+
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+    train_df = train_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Create dataset ID
+    mini_dataset_id = "ScandEval/squad-mini"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api: HfApi = HfApi()
+        api.delete_repo(mini_dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(mini_dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_sst5.py
+++ b/src/scripts/create_sst5.py
@@ -1,0 +1,84 @@
+"""Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main() -> None:
+    """Create the SST5-mini sentiment dataset and upload it to the HF Hub."""
+
+    # Define the base download URL
+    repo_id = "SetFit/sst5"
+
+    # Download the dataset
+    dataset = load_dataset(path=repo_id, token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    # Convert the dataset to a dataframe
+    train_df = dataset["train"].to_pandas()
+    val_df = dataset["validation"].to_pandas()
+    test_df = dataset["test"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(val_df, pd.DataFrame)
+    assert isinstance(test_df, pd.DataFrame)
+
+    # Drop all columns except for `full_text` and `label`
+    columns_to_drop = [
+        col for col in train_df.columns if col not in ["text", "label_text"]
+    ]
+    train_df.drop(columns=columns_to_drop, inplace=True)
+    val_df.drop(columns=columns_to_drop, inplace=True)
+    test_df.drop(columns=columns_to_drop, inplace=True)
+
+    # Rename `label_text` to `label`
+    train_df.rename(columns={"label_text": "label"}, inplace=True)
+    val_df.rename(columns={"label_text": "label"}, inplace=True)
+    test_df.rename(columns={"label_text": "label"}, inplace=True)
+
+    # Remove the "very " prefix from the labels
+    train_df["label"] = train_df["label"].str.replace("very ", "")
+    val_df["label"] = val_df["label"].str.replace("very ", "")
+    test_df["label"] = test_df["label"].str.replace("very ", "")
+
+    # Create validation split
+    val_size = 256
+    val_df = val_df.sample(n=val_size, random_state=4242)
+
+    # Create test split
+    test_size = 2048
+    test_df = test_df.sample(n=test_size, random_state=4242)
+
+    # Create train split
+    train_size = 1024
+    train_df = train_df.sample(n=train_size, random_state=4242)
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split="train"),
+        val=Dataset.from_pandas(val_df, split="val"),
+        test=Dataset.from_pandas(test_df, split="test"),
+    )
+
+    # Create dataset ID
+    dataset_id = "ScandEval/sst5-mini"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api = HfApi()
+        api.delete_repo(dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/load_ud_pos.py
+++ b/src/scripts/load_ud_pos.py
@@ -181,6 +181,24 @@ def load_nldt_pos() -> Dict[str, pd.DataFrame]:
     return load_ud_pos(train_url=train_url, val_url=val_url, test_url=test_url)
 
 
+def load_endt_pos() -> Dict[str, pd.DataFrame]:
+    """Load the part-of-speech part of the English Dependency Treebank.
+
+    Returns:
+        The dataframes, stored in the keys `train`, `val` and `test`.
+    """
+    # Define download URLs
+    base_url = (
+        "https://raw.githubusercontent.com/UniversalDependencies/UD_English-GUM/"
+        "master/en_gum-ud-{}.conllu"
+    )
+    train_url = base_url.format("train")
+    val_url = base_url.format("dev")
+    test_url = base_url.format("test")
+
+    return load_ud_pos(train_url=train_url, val_url=val_url, test_url=test_url)
+
+
 def load_ud_pos(
     train_url: str,
     val_url: str,

--- a/tests/test_named_entity_recognition.py
+++ b/tests/test_named_entity_recognition.py
@@ -6,6 +6,7 @@ from typing import Generator
 import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import (
+    CONLL_EN_CONFIG,
     CONLL_NL_CONFIG,
     DANE_CONFIG,
     GERMEVAL_CONFIG,
@@ -29,6 +30,7 @@ from scandeval.named_entity_recognition import NamedEntityRecognition
         WIKIANN_FO_CONFIG,
         GERMEVAL_CONFIG,
         CONLL_NL_CONFIG,
+        CONLL_EN_CONFIG,
     ],
     ids=[
         "dane",
@@ -39,6 +41,7 @@ from scandeval.named_entity_recognition import NamedEntityRecognition
         "wikiann-fo",
         "germeval",
         "conll-nl",
+        "conll-en",
     ],
 )
 def benchmark_dataset(

--- a/tests/test_question_answering.py
+++ b/tests/test_question_answering.py
@@ -11,6 +11,7 @@ from scandeval.dataset_configs import (
     SCANDIQA_DA_CONFIG,
     SCANDIQA_NO_CONFIG,
     SCANDIQA_SV_CONFIG,
+    SQUAD_CONFIG,
 )
 from scandeval.question_answering import QuestionAnswering, prepare_train_examples
 from transformers import AutoTokenizer
@@ -24,6 +25,7 @@ from transformers import AutoTokenizer
         SCANDIQA_SV_CONFIG,
         NQII_CONFIG,
         GERMANQUAD_CONFIG,
+        SQUAD_CONFIG,
     ],
     ids=[
         "scandiqa-da",
@@ -31,6 +33,7 @@ from transformers import AutoTokenizer
         "scandiqa-sv",
         "nqii",
         "germanquad",
+        "squad",
     ],
 )
 def benchmark_dataset(

--- a/tests/test_sequence_classification.py
+++ b/tests/test_sequence_classification.py
@@ -12,12 +12,14 @@ from scandeval.dataset_configs import (
     SB10K_CONFIG,
     SCALA_DA_CONFIG,
     SCALA_DE_CONFIG,
+    SCALA_EN_CONFIG,
     SCALA_FO_CONFIG,
     SCALA_IS_CONFIG,
     SCALA_NB_CONFIG,
     SCALA_NL_CONFIG,
     SCALA_NN_CONFIG,
     SCALA_SV_CONFIG,
+    SST5_CONFIG,
     SWEREC_CONFIG,
 )
 from scandeval.sequence_classification import SequenceClassification
@@ -31,6 +33,7 @@ from scandeval.sequence_classification import SequenceClassification
         NOREC_CONFIG,
         SB10K_CONFIG,
         DUTCH_SOCIAL_CONFIG,
+        SST5_CONFIG,
         SCALA_DA_CONFIG,
         SCALA_SV_CONFIG,
         SCALA_NB_CONFIG,
@@ -39,6 +42,7 @@ from scandeval.sequence_classification import SequenceClassification
         SCALA_FO_CONFIG,
         SCALA_DE_CONFIG,
         SCALA_NL_CONFIG,
+        SCALA_EN_CONFIG,
     ],
     ids=[
         "angry-tweets",
@@ -46,6 +50,7 @@ from scandeval.sequence_classification import SequenceClassification
         "norec",
         "sb10k",
         "dutch-social",
+        "sst5",
         "scala-da",
         "scala-sv",
         "scala-nb",
@@ -54,6 +59,7 @@ from scandeval.sequence_classification import SequenceClassification
         "scala-fo",
         "scala-de",
         "scala-nl",
+        "scala-en",
     ],
 )
 def benchmark_dataset(

--- a/tests/test_text_to_text.py
+++ b/tests/test_text_to_text.py
@@ -6,6 +6,7 @@ from typing import Generator
 import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import (
+    CNN_DAILYMAIL_CONFIG,
     MLSUM_CONFIG,
     NO_SAMMENDRAG_CONFIG,
     NORDJYLLAND_NEWS_CONFIG,
@@ -25,6 +26,7 @@ from scandeval.text_to_text import TextToText
         RRN_CONFIG,
         MLSUM_CONFIG,
         WIKI_LINGUA_NL_CONFIG,
+        CNN_DAILYMAIL_CONFIG,
     ],
     ids=[
         "nordjylland-news",
@@ -33,6 +35,7 @@ from scandeval.text_to_text import TextToText
         "rrn",
         "mlsum",
         "wiki-lingua-nl",
+        "cnn-dailymail",
     ],
 )
 def benchmark_dataset(


### PR DESCRIPTION
This PR adds the following English datasets:

1. `sst5`, a sentiment classification dataset, where "very positive" and "very negative" has been converted into "positive" and "negative"
2. `scala-en`, a linguistic acceptability dataset created just like the other ScaLA datasets, based on the [GUM universal dependencies treebank](https://github.com/UniversalDependencies/UD_English-GUM/tree/master)
3. `squad`, an extractive QA dataset based on the SQuAD-v2 dataset, where samples without answers have been removed, as with the other ScandEval QA datasets
4. `cnn-dailymail`, a summarisation dataset with summaries of news articles.

The reason for adding English datasets is to be able to distinguish NLU tasks from non-English tasks, to (for instance) see if generative models are bad at NLU tasks in general, or if they're just bad at non-English tasks.