### PR TITLE
Tests/benchmark config factory

### DIFF
--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -126,7 +126,7 @@ def get_correct_language_codes(language_codes: str | list[str]) -> list[str]:
     """Get correct language-code(s).
 
     Args:
-        language:
+        language_codes:
             The language codes of the languages to include, both for models and
             datasets. Here 'no' means both Bokmål (nb) and Nynorsk (nn). Set this
             to 'all' if all languages (also non-Scandinavian) should be considered.
@@ -162,15 +162,15 @@ def prepare_languages(
     """Prepare language(s) for benchmarking.
 
     Args:
-        language:
+        language_codes:
             The language codes of the languages to include for models or datasets.
             If specified then this overrides the `language` parameter for model or
             dataset languages.
-        language_codes:
+        default_language_codes:
             The default language codes of the languages to include.
 
     Returns:
-        The prepared model languages.
+        The prepared model or dataset languages.
     """
     # Create a dictionary that maps languages to their associated language objects
     language_mapping = get_all_languages()

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -85,14 +85,14 @@ def build_benchmark_config(
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model.
     """
-    languages = prepare_languages(language=language)
-    model_languages = prepare_model_languages(
-        model_language=model_language,
-        languages=languages,
+    language_codes = get_correct_language_codes(language=language)
+    model_languages = prepare_languages(
+        language=model_language,
+        language_codes=language_codes,
     )
-    dataset_languages = prepare_dataset_languages(
-        dataset_language=dataset_language,
-        languages=languages,
+    dataset_languages = prepare_languages(
+        language=dataset_language,
+        language_codes=language_codes,
     )
 
     dataset_tasks = prepare_dataset_tasks(dataset_task=dataset_task)
@@ -122,8 +122,8 @@ def build_benchmark_config(
     )
 
 
-def prepare_languages(language: str | list[str]) -> list[str]:
-    """Prepare language(s) for benchmarking.
+def get_correct_language_codes(language: str | list[str]) -> list[str]:
+    """Get correct language-code(s).
 
     Args:
         language:
@@ -132,7 +132,7 @@ def prepare_languages(language: str | list[str]) -> list[str]:
             to 'all' if all languages (also non-Scandinavian) should be considered.
 
     Returns:
-        The prepared languages.
+        The correct language-codes.
     """
     # Create a dictionary that maps languages to their associated language objects
     language_mapping = get_all_languages()
@@ -155,17 +155,18 @@ def prepare_languages(language: str | list[str]) -> list[str]:
     return languages
 
 
-def prepare_model_languages(
-    model_language: str | list[str] | None,
-    languages: list[str],
+def prepare_languages(
+    language: str | list[str] | None,
+    language_codes: list[str],
 ) -> list[Language]:
-    """Prepare model language(s) for benchmarking.
+    """Prepare language(s) for benchmarking.
 
     Args:
-        model_language:
-            The language codes of the languages to include for models. If specified
-            then this overrides the `language` parameter for model languages.
-        languages:
+        language:
+            The language codes of the languages to include for models or datasets.
+            If specified then this overrides the `language` parameter for model or
+            dataset languages.
+        language_codes:
             The default language codes of the languages to include.
 
     Returns:
@@ -175,63 +176,21 @@ def prepare_model_languages(
     language_mapping = get_all_languages()
 
     # Create the list `model_languages`
-    model_languages_str: list[str]
-    if model_language is None:
-        model_languages_str = languages
-    elif isinstance(model_language, str):
-        model_languages_str = [model_language]
+    languages_str: list[str]
+    if language is None:
+        languages_str = language_codes
+    elif isinstance(language, str):
+        languages_str = [language]
     else:
-        model_languages_str = model_language
+        languages_str = language
 
     # Convert the model languages to language objects
-    if "all" in model_languages_str:
-        model_languages = list(language_mapping.values())
+    if "all" in languages_str:
+        prepared_languages = list(language_mapping.values())
     else:
-        model_languages = [
-            language_mapping[language] for language in model_languages_str
-        ]
+        prepared_languages = [language_mapping[language] for language in languages_str]
 
-    return model_languages
-
-
-def prepare_dataset_languages(
-    dataset_language: str | list[str] | None,
-    languages: list[str],
-) -> list[Language]:
-    """Prepare dataset language(s) for benchmarking.
-
-    Args:
-        model_language:
-            The language codes of the languages to include for datasets. If
-            specified then this overrides the `language` parameter for dataset
-            languages.
-        languages:
-            The default language codes of the languages to include.
-
-    Returns:
-        The prepared dataset languages.
-    """
-    # Create a dictionary that maps languages to their associated language objects
-    language_mapping = get_all_languages()
-
-    # Create the list `dataset_languages_str`
-    dataset_languages_str: list[str]
-    if dataset_language is None:
-        dataset_languages_str = languages
-    elif isinstance(dataset_language, str):
-        dataset_languages_str = [dataset_language]
-    else:
-        dataset_languages_str = dataset_language
-
-    # Convert the dataset languages to language objects
-    if "all" in dataset_languages_str:
-        dataset_languages = list(language_mapping.values())
-    else:
-        dataset_languages = [
-            language_mapping[language] for language in dataset_languages_str
-        ]
-
-    return dataset_languages
+    return prepared_languages
 
 
 def prepare_dataset_tasks(dataset_task: str | list[str] | None) -> list[DatasetTask]:

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -87,12 +87,12 @@ def build_benchmark_config(
     """
     language_codes = get_correct_language_codes(language_codes=language)
     model_languages = prepare_languages(
-        language=model_language,
-        language_codes=language_codes,
+        language_codes=model_language,
+        default_language_codes=language_codes,
     )
     dataset_languages = prepare_languages(
-        language=dataset_language,
-        language_codes=language_codes,
+        language_codes=dataset_language,
+        default_language_codes=language_codes,
     )
 
     dataset_tasks = prepare_dataset_tasks(dataset_task=dataset_task)
@@ -156,8 +156,8 @@ def get_correct_language_codes(language_codes: str | list[str]) -> list[str]:
 
 
 def prepare_languages(
-    language: str | list[str] | None,
-    language_codes: list[str],
+    language_codes: str | list[str] | None,
+    default_language_codes: list[str],
 ) -> list[Language]:
     """Prepare language(s) for benchmarking.
 
@@ -177,12 +177,12 @@ def prepare_languages(
 
     # Create the list `model_languages`
     languages_str: list[str]
-    if language is None:
-        languages_str = language_codes
-    elif isinstance(language, str):
-        languages_str = [language]
+    if language_codes is None:
+        languages_str = default_language_codes
+    elif isinstance(language_codes, str):
+        languages_str = [language_codes]
     else:
-        languages_str = language
+        languages_str = language_codes
 
     # Convert the model languages to language objects
     if "all" in languages_str:

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -85,7 +85,7 @@ def build_benchmark_config(
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model.
     """
-    language_codes = get_correct_language_codes(language=language)
+    language_codes = get_correct_language_codes(language_codes=language)
     model_languages = prepare_languages(
         language=model_language,
         language_codes=language_codes,
@@ -122,7 +122,7 @@ def build_benchmark_config(
     )
 
 
-def get_correct_language_codes(language: str | list[str]) -> list[str]:
+def get_correct_language_codes(language_codes: str | list[str]) -> list[str]:
     """Get correct language-code(s).
 
     Args:
@@ -138,12 +138,12 @@ def get_correct_language_codes(language: str | list[str]) -> list[str]:
     language_mapping = get_all_languages()
 
     # Create the list `languages`
-    if "all" in language:
+    if "all" in language_codes:
         languages = list(language_mapping.keys())
-    elif isinstance(language, str):
-        languages = [language]
+    elif isinstance(language_codes, str):
+        languages = [language_codes]
     else:
-        languages = language
+        languages = language_codes
 
     # If `languages` contains 'no' then also include 'nb' and 'nn'. Conversely, if
     # either 'nb' or 'nn' are specified then also include 'no'.

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -175,7 +175,7 @@ def prepare_languages(
     # Create a dictionary that maps languages to their associated language objects
     language_mapping = get_all_languages()
 
-    # Create the list `model_languages`
+    # Create the list `languages_str` of language codes to use for models or datasets
     languages_str: list[str]
     if language_codes is None:
         languages_str = default_language_codes

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -40,7 +40,7 @@ def test_get_correct_language_codes(input_language_codes, expected_language_code
 @pytest.mark.parametrize(
     argnames=[
         "input_language_codes",
-        "input_model_language",
+        "input_language",
         "expected_model_language",
     ],
     argvalues=[

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -1,12 +1,15 @@
 """Unit tests for the `benchmark_config_factory` module."""
 
 import pytest
+import torch
 from scandeval.benchmark_config_factory import (
     get_correct_language_codes,
     prepare_dataset_tasks,
+    prepare_device,
     prepare_languages,
 )
 from scandeval.dataset_tasks import LA, NER, get_all_dataset_tasks
+from scandeval.enums import CPU
 from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
 
 
@@ -85,3 +88,26 @@ def test_prepare_languages(
 def test_prepare_dataset_tasks(input_task, expected_task):
     prepared_tasks = prepare_dataset_tasks(dataset_task=input_task)
     assert prepared_tasks == expected_task
+
+
+@pytest.mark.parametrize(
+    argnames=["device" "expected_device"],
+    argvalues=[
+        (CPU, torch.device("cpu")),
+        (
+            None,
+            torch.device("cuda")
+            if torch.cuda.is_available()
+            else torch.device("mps")
+            if torch.backends.mps.is_available()
+            else torch.device("cpu"),
+        ),
+    ],
+    ids=[
+        "device provided",
+        "device not provided",
+    ],
+)
+def test_prepare_device(device, expected_device):
+    prepared_device = prepare_device(device=device)
+    assert prepared_device == expected_device

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -2,8 +2,8 @@
 
 import pytest
 from scandeval.benchmark_config_factory import (
+    get_correct_language_codes,
     prepare_languages,
-    prepare_model_languages,
 )
 from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
 
@@ -27,8 +27,8 @@ from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
         "all -> all languages",
     ],
 )
-def test_prepare_languages(input_language, expected_language):
-    languages = prepare_languages(language=input_language)
+def test_get_correct_language_codes(input_language, expected_language):
+    languages = get_correct_language_codes(language=input_language)
     assert set(languages) == set(expected_language)
 
 
@@ -53,11 +53,11 @@ def test_prepare_languages(input_language, expected_language):
         "all -> all languages",
     ],
 )
-def test_prepare_model_languages(
+def test_prepare_languages(
     input_language, input_model_language, expected_model_language
 ):
-    prepared_languages = prepare_languages(input_language)
-    model_languages = prepare_model_languages(
+    prepared_languages = get_correct_language_codes(input_language)
+    model_languages = prepare_languages(
         model_language=input_model_language, languages=prepared_languages
     )
     model_languages = sorted(model_languages, key=lambda x: x.code)

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -9,7 +9,7 @@ from scandeval.benchmark_config_factory import (
     prepare_languages,
 )
 from scandeval.dataset_tasks import LA, NER, get_all_dataset_tasks
-from scandeval.enums import CPU
+from scandeval.enums import Device
 from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
 
 
@@ -93,7 +93,7 @@ def test_prepare_dataset_tasks(input_task, expected_task):
 @pytest.mark.parametrize(
     argnames=["device" "expected_device"],
     argvalues=[
-        (CPU, torch.device("cpu")),
+        (Device.CPU, torch.device("cpu")),
         (
             None,
             torch.device("cuda")

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -67,7 +67,7 @@ def test_prepare_languages(input_language_codes, input_language, expected_langua
         language_codes=input_language_codes
     )
     model_languages = prepare_languages(
-        language=input_language, language_codes=prepared_language_codes
+        language_codes=input_language, default_language_codes=prepared_language_codes
     )
     model_languages = sorted(model_languages, key=lambda x: x.code)
     expected_language = sorted(expected_language, key=lambda x: x.code)

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -62,18 +62,16 @@ def test_get_correct_language_codes(input_language_codes, expected_language_code
         "all -> all languages",
     ],
 )
-def test_prepare_languages(
-    input_language_codes, input_model_language, expected_model_language
-):
+def test_prepare_languages(input_language_codes, input_language, expected_language):
     prepared_language_codes = get_correct_language_codes(
         language_codes=input_language_codes
     )
     model_languages = prepare_languages(
-        language=input_model_language, language_codes=prepared_language_codes
+        language=input_language, language_codes=prepared_language_codes
     )
     model_languages = sorted(model_languages, key=lambda x: x.code)
-    expected_model_language = sorted(expected_model_language, key=lambda x: x.code)
-    assert model_languages == expected_model_language
+    expected_language = sorted(expected_language, key=lambda x: x.code)
+    assert model_languages == expected_language
 
 
 @pytest.mark.parametrize(

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -1,1 +1,65 @@
 """Unit tests for the `benchmark_config_factory` module."""
+
+import pytest
+from scandeval.benchmark_config_factory import (
+    prepare_languages,
+    prepare_model_languages,
+)
+from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
+
+
+@pytest.mark.parametrize(
+    argnames=["input_language", "expected_language"],
+    argvalues=[
+        ("da", ["da"]),
+        (["da"], ["da"]),
+        (["da", "en"], ["da", "en"]),
+        ("no", ["no", "nb", "nn"]),
+        (["nb"], ["nb", "no"]),
+        ("all", list(get_all_languages().keys())),
+    ],
+    ids=[
+        "single language",
+        "single language as list",
+        "multiple languages",
+        "no -> no + nb + nn",
+        "nb -> nb + no",
+        "all -> all languages",
+    ],
+)
+def test_prepare_languages(input_language, expected_language):
+    languages = prepare_languages(language=input_language)
+    assert set(languages) == set(expected_language)
+
+
+@pytest.mark.parametrize(
+    argnames=["input_language", "input_model_language", "expected_model_language"],
+    argvalues=[
+        ("da", None, [DA]),
+        (["da"], None, [DA]),
+        (["da", "no"], ["da"], [DA]),
+        (["da", "en"], None, [DA, EN]),
+        ("no", None, [NO, NB, NN]),
+        (["nb"], None, [NB, NO]),
+        ("all", None, list(get_all_languages().values())),
+    ],
+    ids=[
+        "single language",
+        "single language as list",
+        "language takes precedence over model language",
+        "multiple languages",
+        "no -> no + nb + nn",
+        "nb -> nb + no",
+        "all -> all languages",
+    ],
+)
+def test_prepare_model_languages(
+    input_language, input_model_language, expected_model_language
+):
+    prepared_languages = prepare_languages(input_language)
+    model_languages = prepare_model_languages(
+        model_language=input_model_language, languages=prepared_languages
+    )
+    model_languages = sorted(model_languages, key=lambda x: x.code)
+    expected_model_language = sorted(expected_model_language, key=lambda x: x.code)
+    assert model_languages == expected_model_language

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -41,7 +41,7 @@ def test_get_correct_language_codes(input_language_codes, expected_language_code
     argnames=[
         "input_language_codes",
         "input_language",
-        "expected_model_language",
+        "expected_language",
     ],
     argvalues=[
         ("da", None, [DA]),

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -14,7 +14,7 @@ from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
 
 
 @pytest.mark.parametrize(
-    argnames=["input_language", "expected_language"],
+    argnames=["input_language_codes", "expected_language_codes"],
     argvalues=[
         ("da", ["da"]),
         (["da"], ["da"]),
@@ -32,13 +32,17 @@ from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
         "all -> all languages",
     ],
 )
-def test_get_correct_language_codes(input_language, expected_language):
-    languages = get_correct_language_codes(language=input_language)
-    assert set(languages) == set(expected_language)
+def test_get_correct_language_codes(input_language_codes, expected_language_codes):
+    languages = get_correct_language_codes(language_codes=input_language_codes)
+    assert set(languages) == set(expected_language_codes)
 
 
 @pytest.mark.parametrize(
-    argnames=["input_language", "input_model_language", "expected_model_language"],
+    argnames=[
+        "input_language_codes",
+        "input_model_language",
+        "expected_model_language",
+    ],
     argvalues=[
         ("da", None, [DA]),
         (["da"], None, [DA]),
@@ -59,11 +63,13 @@ def test_get_correct_language_codes(input_language, expected_language):
     ],
 )
 def test_prepare_languages(
-    input_language, input_model_language, expected_model_language
+    input_language_codes, input_model_language, expected_model_language
 ):
-    prepared_languages = get_correct_language_codes(input_language)
+    prepared_language_codes = get_correct_language_codes(
+        language_codes=input_language_codes
+    )
     model_languages = prepare_languages(
-        model_language=input_model_language, languages=prepared_languages
+        language=input_model_language, language_codes=prepared_language_codes
     )
     model_languages = sorted(model_languages, key=lambda x: x.code)
     expected_model_language = sorted(expected_model_language, key=lambda x: x.code)
@@ -91,7 +97,7 @@ def test_prepare_dataset_tasks(input_task, expected_task):
 
 
 @pytest.mark.parametrize(
-    argnames=["device" "expected_device"],
+    argnames=["device", "expected_device"],
     argvalues=[
         (Device.CPU, torch.device("cpu")),
         (

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -3,8 +3,10 @@
 import pytest
 from scandeval.benchmark_config_factory import (
     get_correct_language_codes,
+    prepare_dataset_tasks,
     prepare_languages,
 )
+from scandeval.dataset_tasks import LA, NER, get_all_dataset_tasks
 from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
 
 
@@ -63,3 +65,23 @@ def test_prepare_languages(
     model_languages = sorted(model_languages, key=lambda x: x.code)
     expected_model_language = sorted(expected_model_language, key=lambda x: x.code)
     assert model_languages == expected_model_language
+
+
+@pytest.mark.parametrize(
+    argnames=["input_task", "expected_task"],
+    argvalues=[
+        (None, list(get_all_dataset_tasks.values())),
+        ("linguistic-acceptability", [LA]),
+        (["linguistic-acceptability"], [LA]),
+        (["linguistic-acceptability", "named-entity-recognition"], [LA, NER]),
+    ],
+    ids=[
+        "all tasks",
+        "single task",
+        "single task as list",
+        "multiple tasks",
+    ],
+)
+def test_prepare_dataset_tasks(input_task, expected_task):
+    prepared_tasks = prepare_dataset_tasks(dataset_task=input_task)
+    assert prepared_tasks == expected_task

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -73,7 +73,7 @@ def test_prepare_languages(
 @pytest.mark.parametrize(
     argnames=["input_task", "expected_task"],
     argvalues=[
-        (None, list(get_all_dataset_tasks.values())),
+        (None, list(get_all_dataset_tasks().values())),
         ("linguistic-acceptability", [LA]),
         (["linguistic-acceptability"], [LA]),
         (["linguistic-acceptability", "named-entity-recognition"], [LA, NER]),


### PR DESCRIPTION
This PR adds tests of the `benchmark_config_factory.py`-module. Furthermore it merges the two identical functions `prepare_dataset_languages` and `prepare_model_languages`, and renames accordingly.

This closes #47 