### PR TITLE
feat: Add `--only-validation-split` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
       translated version of SQuAD-v2. As with the datasets mentioned above, this is
       meant as a first version of a Dutch QA dataset, until we have a better one
       available.
+- Added `--only-validation-split` flag, which only benchmarks the model on the
+  validation split, which is 5-10x smaller than the test split (depending on the
+  dataset). This is especially useful with paid models like OpenAI models. The value of
+  this flag is stored in the benchmark results, so this will be visible on
+  leaderboards.
 
 ### Changed
 - Now compatible with`transformers >= 4.36.2`, and this is required now as they have

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -28,6 +28,7 @@ def build_benchmark_config(
     load_in_4bit: bool | None,
     use_flash_attention: bool,
     clear_model_cache: bool,
+    only_validation_split: bool,
 ) -> BenchmarkConfig:
     """Create a benchmark configuration.
 
@@ -84,6 +85,8 @@ def build_benchmark_config(
             Whether to use Flash Attention.
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model.
+        only_validation_split:
+            Whether to only evaluate on the validation split.
     """
     languages = prepare_languages(language=language)
     model_languages = prepare_model_languages(
@@ -99,7 +102,6 @@ def build_benchmark_config(
 
     torch_device = prepare_device(device=device)
 
-    # Build benchmark config and return it
     return BenchmarkConfig(
         model_languages=model_languages,
         dataset_languages=dataset_languages,
@@ -119,6 +121,7 @@ def build_benchmark_config(
         load_in_4bit=load_in_4bit,
         use_flash_attention=use_flash_attention,
         clear_model_cache=clear_model_cache,
+        only_validation_split=only_validation_split,
     )
 
 

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -263,6 +263,7 @@ class BenchmarkDataset(ABC):
             max_sequence_length=max_seq_length,
             vocabulary_size=vocab_size,
             few_shot=model_is_generative(model=model),
+            validation_split=self.benchmark_config.only_validation_split,
         )
 
         # Log the metadata
@@ -327,6 +328,9 @@ class BenchmarkDataset(ABC):
         train = dataset_dict["train"]
         val = dataset_dict["val"]
         test = dataset_dict["test"]
+
+        if self.benchmark_config.only_validation_split:
+            test = val
 
         # Remove empty examples from the datasets
         for text_feature in ["tokens", "text"]:

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -104,6 +104,9 @@ class Benchmarker:
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model. Defaults to
             False.
+        only_validation_split:
+            Whether to only evaluate the validation split of the datasets. Defaults to
+            False.
 
     Attributes:
         progress_bar: Whether progress bars should be shown.
@@ -138,6 +141,7 @@ class Benchmarker:
         load_in_4bit: bool | None = None,
         use_flash_attention: bool = False,
         clear_model_cache: bool = False,
+        only_validation_split: bool = False,
     ) -> None:
         self.benchmark_config = build_benchmark_config(
             language=language,
@@ -159,6 +163,7 @@ class Benchmarker:
             load_in_4bit=load_in_4bit,
             use_flash_attention=use_flash_attention,
             clear_model_cache=clear_model_cache,
+            only_validation_split=only_validation_split,
         )
 
         # Set attributes from arguments

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -188,6 +188,12 @@ from .languages import get_all_languages
     show_default=True,
     help="Whether to clear the model cache after benchmarking each model.",
 )
+@click.option(
+    "--only-validation-split/--no-only-validation-split",
+    default=False,
+    show_default=True,
+    help="Whether to only evaluate on the validation split.",
+)
 def benchmark(
     model_id: tuple[str],
     dataset: tuple[str],
@@ -211,6 +217,7 @@ def benchmark(
     load_in_4bit: bool | None,
     use_flash_attention: bool,
     clear_model_cache: bool,
+    only_validation_split: bool,
 ) -> None:
     """Benchmark pretrained language models on language tasks."""
 
@@ -246,6 +253,7 @@ def benchmark(
         load_in_4bit=load_in_4bit,
         use_flash_attention=use_flash_attention,
         clear_model_cache=clear_model_cache,
+        only_validation_split=only_validation_split,
     )
 
     # Perform the benchmark evaluation

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -127,6 +127,8 @@ class BenchmarkConfig:
             Whether to use Flash Attention.
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model.
+        only_validation_split:
+            Whether to only evaluate on the validation split.
     """
 
     model_languages: list[Language]
@@ -147,6 +149,7 @@ class BenchmarkConfig:
     load_in_4bit: bool | None
     use_flash_attention: bool
     clear_model_cache: bool
+    only_validation_split: bool
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def benchmark_config() -> Generator[BenchmarkConfig, None, None]:
         load_in_4bit=None,
         use_flash_attention=False,
         clear_model_cache=False,
+        only_validation_split=False,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ def test_cli_param_names(params):
         "load_in_4bit",
         "use_flash_attention",
         "clear_model_cache",
+        "only_validation_split",
         "help",
     }
 
@@ -62,4 +63,5 @@ def test_cli_param_types(params):
     assert params["load_in_4bit"] == BOOL
     assert params["use_flash_attention"] == BOOL
     assert params["clear_model_cache"] == BOOL
+    assert params["only_validation_split"] == BOOL
     assert params["help"] == BOOL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,6 +109,7 @@ class TestBenchmarkConfig:
             load_in_4bit=None,
             use_flash_attention=False,
             clear_model_cache=False,
+            only_validation_split=False,
         )
 
     def test_benchmark_config_is_object(self, benchmark_config):
@@ -135,6 +136,7 @@ class TestBenchmarkConfig:
         assert benchmark_config.load_in_4bit is None
         assert benchmark_config.use_flash_attention is False
         assert benchmark_config.clear_model_cache is False
+        assert benchmark_config.only_validation_split is False
 
 
 class TestDatasetConfig:


### PR DESCRIPTION
### Added
- Added `--only-validation-split` flag, which only benchmarks the model on the validation split, which is 5-10x smaller than the test split (depending on the dataset). This is especially useful with paid models like OpenAI models. The value of this flag is stored in the benchmark results, so this will be visible on leaderboards.