### PR TITLE
fix: Set ignore_mismatched_sizes if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When benchmarking encoder models on QA tasks the contexts are split up if they exceed
   the model's context length. The stride value used caused errors in rare cases where
   the model's maximum context length was really small (128). This has been fixed now.
+- Now sets `ignore_mismatched_sizes` when loading models if the model cannot be loaded
+  otherwise. This previously caused some issues when loading certain models.
 
 
 ## [v8.2.1] - 2023-12-20

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -291,8 +291,8 @@ class HFModelSetup:
                                 "flash-attn`."
                             )
                     except (KeyError, RuntimeError) as e:
-                        if not ignore_mismatched_sizes:
-                            ignore_mismatched_sizes = True
+                        if not model_kwargs["ignore_mismatched_sizes"]:
+                            model_kwargs["ignore_mismatched_sizes"] = True
                             continue
                         else:
                             raise InvalidBenchmark(str(e))

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -292,6 +292,11 @@ class HFModelSetup:
                             )
                     except (KeyError, RuntimeError) as e:
                         if not model_kwargs["ignore_mismatched_sizes"]:
+                            logger.warning(
+                                f"{type(e).__name__} occurred during the benchmarking "
+                                "of the {model_id!r} model. Retrying with "
+                                "`ignore_mismatched_sizes` set to True."
+                            )
                             model_kwargs["ignore_mismatched_sizes"] = True
                             continue
                         else:

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -292,7 +292,7 @@ class HFModelSetup:
                             )
                     except (KeyError, RuntimeError) as e:
                         if not model_kwargs["ignore_mismatched_sizes"]:
-                            logger.warning(
+                            logger.debug(
                                 f"{type(e).__name__} occurred during the loading "
                                 f"of the {model_id!r} model. Retrying with "
                                 "`ignore_mismatched_sizes` set to True."

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -294,7 +294,7 @@ class HFModelSetup:
                         if not model_kwargs["ignore_mismatched_sizes"]:
                             logger.warning(
                                 f"{type(e).__name__} occurred during the benchmarking "
-                                "of the {model_id!r} model. Retrying with "
+                                f"of the {model_id!r} model. Retrying with "
                                 "`ignore_mismatched_sizes` set to True."
                             )
                             model_kwargs["ignore_mismatched_sizes"] = True

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -293,7 +293,7 @@ class HFModelSetup:
                     except (KeyError, RuntimeError) as e:
                         if not model_kwargs["ignore_mismatched_sizes"]:
                             logger.warning(
-                                f"{type(e).__name__} occurred during the benchmarking "
+                                f"{type(e).__name__} occurred during the loading "
                                 f"of the {model_id!r} model. Retrying with "
                                 "`ignore_mismatched_sizes` set to True."
                             )


### PR DESCRIPTION
### Fixed
- Now sets `ignore_mismatched_sizes` when loading models if the model cannot be loaded otherwise. This previously caused some issues when loading certain models.