### PR TITLE
feat: DANSK replaces DaNE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   cached model outputs or datasets.
 - Added the following new datasets:
     - `fone`, a Faroese NER dataset, which replaces the previous `wikiann-fo` dataset.
-    - `dansk`, a Danish NER dataset, which complements the previous `dane` dataset.
+    - `dansk`, a Danish NER dataset, which replaces the previous `dane` dataset.
     - `norquad`, a Norwegian question answering dataset, which replaces the previous
       `scandiqa-no` dataset.
     - Danish, Swedish, German and Dutch versions of the MMLU, ARC and HellaSwag

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -200,29 +200,6 @@ SUC3_CONFIG = DatasetConfig(
     max_generated_tokens=128,
 )
 
-DANE_CONFIG = DatasetConfig(
-    name="dane",
-    pretty_name="the truncated version of DaNE",
-    huggingface_id="ScandEval/dane-mini",
-    task=NER,
-    languages=[DA],
-    prompt_prefix="Følgende er sætninger og JSON-ordbøger med de navngivne enheder, "
-    "som forekommer i den givne sætning.",
-    prompt_template="Sætning: {text}\nNavngivne enheder: {label}",
-    prompt_label_mapping={
-        "b-per": "person",
-        "i-per": "person",
-        "b-loc": "sted",
-        "i-loc": "sted",
-        "b-org": "organisation",
-        "i-org": "organisation",
-        "b-misc": "diverse",
-        "i-misc": "diverse",
-    },
-    num_few_shot_examples=8,
-    max_generated_tokens=128,
-)
-
 DANSK_CONFIG = DatasetConfig(
     name="dansk",
     pretty_name="the truncated version of DANSK",

--- a/tests/test_named_entity_recognition.py
+++ b/tests/test_named_entity_recognition.py
@@ -8,7 +8,6 @@ from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import (
     CONLL_EN_CONFIG,
     CONLL_NL_CONFIG,
-    DANE_CONFIG,
     DANSK_CONFIG,
     FONE_CONFIG,
     GERMEVAL_CONFIG,
@@ -25,7 +24,6 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
 @pytest.fixture(
     scope="module",
     params=[
-        DANE_CONFIG,
         DANSK_CONFIG,
         SUC3_CONFIG,
         NORNE_NB_CONFIG,
@@ -37,7 +35,6 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
         CONLL_EN_CONFIG,
     ],
     ids=[
-        "dane",
         "dansk",
         "suc3",
         "norne_nb",


### PR DESCRIPTION
The [DANSK dataset](https://openreview.net/forum?id=_ONCiIHe-wU) is a new Danish NER dataset, which has been more thoroughly annotated and which cover a more diverse amount of Danish text (from gigaword). A tentative performance correlation analysis on 50+ models shows that there is a ~93% correlation between the two benchmark datasets, meaning that it doesn't make sense keeping both.

When #96 gets implemented, this further allows for even more NER tags, making the task more challenging.

![Screenshot 2024-01-04 at 15 51 10](https://github.com/ScandEval/ScandEval/assets/47701536/192d37b7-f240-4417-9f70-ef73a8b33525)