### PR TITLE
fix: Ensure that samples are small enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   previously.
 - Now doesn't force ASCII characters in the NER task for generative models, making the
   target JSON dictionary more consistent with the input text.
+- Samples with excessively short or long texts have been removed, being contexts whose
+  lengths are in the top-5% or bottom-5%.
+- Adjusted number of few-shot examples in datasets to ensure that the resulting prompt
+  is at most ~3000 tokens long.
 
 ### Fixed
 - Removed `text2text-generation` temporarily from the tags defining generative models,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   previously.
 - Now doesn't force ASCII characters in the NER task for generative models, making the
   target JSON dictionary more consistent with the input text.
-- Samples with excessively short or long texts have been removed, being contexts whose
-  lengths are in the top-5% or bottom-5%.
+- Samples with excessively short or long texts have been removed.
 - Adjusted number of few-shot examples in datasets to ensure that the resulting prompt
   is at most ~3000 tokens long.
 

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -498,7 +498,8 @@ SCALA_EN_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/scala-en",
     task=LA,
     languages=[EN],
-    prompt_prefix="The following are sentences and whether they are grammatically correct.",
+    prompt_prefix="The following are sentences and whether they are grammatically "
+    "correct.",
     prompt_template="Sentence: {text}\nGrammatically correct: {label}",
     prompt_label_mapping=dict(correct="yes", incorrect="no"),
     num_few_shot_examples=12,
@@ -514,7 +515,9 @@ SCANDIQA_DA_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/scandiqa-da-mini",
     task=QA,
     languages=[DA],
-    prompt_template="{text}\nSpørgsmål: {question}\nSvar med maks. 3 ord: {label}",
+    prompt_prefix="Følgende er tekster med tilhørende spørgsmål og svar.",
+    prompt_template="Tekst: {text}\nSpørgsmål: {question}\nSvar med maks. 3 ord: "
+    "{label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
@@ -525,8 +528,9 @@ NORQUAD_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/norquad-mini",
     task=QA,
     languages=[NB, NN],
-    prompt_template="{text}\nSpørsmål: {question}\nSvar på maks 3 ord: {label}",
-    num_few_shot_examples=4,
+    prompt_prefix="Her følger tekster med tilhørende spørsmål og svar.",
+    prompt_template="Tekst: {text}\nSpørsmål: {question}\nSvar på maks 3 ord: {label}",
+    num_few_shot_examples=2,
     max_generated_tokens=32,
 )
 
@@ -536,7 +540,8 @@ SCANDIQA_SV_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/scandiqa-sv-mini",
     task=QA,
     languages=[SV],
-    prompt_template="{text}\nFråga: {question}\nSvar på max 3 ord: {label}",
+    prompt_prefix="Nedan följer texter med tillhörande frågor och svar.",
+    prompt_template="Text: {text}\nFråga: {question}\nSvar på max 3 ord: {label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
@@ -547,8 +552,9 @@ NQII_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/nqii-mini",
     task=QA,
     languages=[IS],
-    prompt_template="{text}\nSpurning: {question}\nSvaraðu með að hámarki 3 orðum: "
-    "{label}",
+    prompt_prefix="Eftirfarandi eru textar með tilheyrandi spurningum og svörum.",
+    prompt_template="Texti: {text}\nSpurning: {question}\nSvaraðu með að hámarki 3 "
+    "orðum: {label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
@@ -571,7 +577,9 @@ GERMANQUAD_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/germanquad-mini",
     task=QA,
     languages=[DE],
-    prompt_template="{text}\nFragen: {question}\nFragen Antwort in maximal 3 "
+    prompt_prefix="Im Folgenden finden Sie Texte mit den dazugehörigen Fragen und "
+    "Antworten.",
+    prompt_template="Text: {text}\nFragen: {question}\nFragen Antwort in maximal 3 "
     "Wörtern: {label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
@@ -583,7 +591,9 @@ SQUAD_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/squad-mini",
     task=QA,
     languages=[EN],
-    prompt_template="{text}\nQuestion: {question}\nAnswer in max 3 words: {label}",
+    prompt_prefix="The following are texts with accompanying questions and answers.",
+    prompt_template="Text: {text}\nQuestion: {question}\nAnswer in max 3 words: "
+    "{label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
@@ -594,7 +604,9 @@ SQUAD_NL_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/squad-nl-mini",
     task=QA,
     languages=[NL],
-    prompt_template="{text}\nVraag: {question}\nAntwoord in max 3 woorden: {label}",
+    prompt_prefix="Hieronder volgen teksten met bijbehorende vragen en antwoorden.",
+    prompt_template="Tekst: {text}\nVraag: {question}\nAntwoord in max 3 woorden: "
+    "{label}",
     num_few_shot_examples=4,
     max_generated_tokens=32,
 )
@@ -610,7 +622,8 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/nordjylland-news-mini",
     task=SUMM,
     languages=[DA],
-    prompt_template="{text}\nOpsummering: {target_text}",
+    prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
+    prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
@@ -621,8 +634,10 @@ MLSUM_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/mlsum-mini",
     task=SUMM,
     languages=[DE],
-    prompt_template="{text}\nZusammenfassung: {target_text}",
-    num_few_shot_examples=2,
+    prompt_prefix="Im Folgenden finden Sie Nachrichtenartikel mit den dazugehörigen "
+    "Zusammenfassungen.",
+    prompt_template="Nachrichtenartikel: {text}\nZusammenfassung: {target_text}",
+    num_few_shot_examples=1,
     max_generated_tokens=128,
 )
 
@@ -632,7 +647,8 @@ RRN_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/rrn-mini",
     task=SUMM,
     languages=[IS],
-    prompt_template="{text}\nSamantekt: {target_text}",
+    prompt_prefix="Eftirfarandi eru fréttagreinar með tilheyrandi samantektum.",
+    prompt_template="Fréttagrein: {text}\nSamantekt: {target_text}",
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
@@ -643,7 +659,8 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/no-sammendrag-mini",
     task=SUMM,
     languages=[NB, NN],
-    prompt_template="{text}\nSammendrag: {target_text}",
+    prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
+    prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
@@ -654,7 +671,8 @@ WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/wiki-lingua-nl-mini",
     task=SUMM,
     languages=[NL],
-    prompt_template="{text}\nSamenvatting: {target_text}",
+    prompt_prefix="Hieronder volgen artikelen met bijbehorende samenvattingen.",
+    prompt_template="Artikel: {text}\nSamenvatting: {target_text}",
     num_few_shot_examples=2,
     max_generated_tokens=128,
 )
@@ -665,8 +683,9 @@ SWEDN_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/swedn-mini",
     task=SUMM,
     languages=[SV],
-    prompt_template="{text}\nSammanfattning: {target_text}",
-    num_few_shot_examples=2,
+    prompt_prefix="Nedan följer artiklar med tillhörande sammanfattningar.",
+    prompt_template="Artikel: {text}\nSammanfattning: {target_text}",
+    num_few_shot_examples=1,
     max_generated_tokens=128,
 )
 
@@ -676,8 +695,9 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     huggingface_id="ScandEval/cnn-dailymail-mini",
     task=SUMM,
     languages=[EN],
-    prompt_template="{text}\nSummary: {target_text}",
-    num_few_shot_examples=2,
+    prompt_prefix="The following are articles with accompanying summaries.",
+    prompt_template="News article: {text}\nSummary: {target_text}",
+    num_few_shot_examples=1,
     max_generated_tokens=128,
 )
 
@@ -747,7 +767,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_prefix="Følgende er multiple choice spørgsmål (med svar).",
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=25,
+    num_few_shot_examples=20,
     max_generated_tokens=3,
 )
 
@@ -760,7 +780,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_prefix="Följande är flervalsfrågor (med svar).",
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=25,
+    num_few_shot_examples=20,
     max_generated_tokens=3,
 )
 
@@ -773,7 +793,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_prefix="Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).",
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=25,
+    num_few_shot_examples=20,
     max_generated_tokens=3,
 )
 
@@ -786,7 +806,7 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_prefix="Hieronder staan meerkeuzevragen (met antwoorden).",
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=25,
+    num_few_shot_examples=20,
     max_generated_tokens=3,
 )
 
@@ -798,7 +818,7 @@ ARC_NL_CONFIG = DatasetConfig(
 ### COMMON SENSE REASONING DATASETS ###
 
 HELLASWAG_DA_CONFIG = DatasetConfig(
-    name="mmlu-da",
+    name="hellaswag-da",
     pretty_name="the Danish part of the truncated version of MMLU",
     huggingface_id="ScandEval/hellaswag-da-mini",
     task=COMMON_SENSE,
@@ -806,12 +826,12 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_prefix="Følgende er multiple choice spørgsmål (med svar).",
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=10,
+    num_few_shot_examples=5,
     max_generated_tokens=3,
 )
 
 HELLASWAG_SV_CONFIG = DatasetConfig(
-    name="mmlu-sv",
+    name="hellaswag-sv",
     pretty_name="the Swedish part of the truncated version of MMLU",
     huggingface_id="ScandEval/hellaswag-sv-mini",
     task=COMMON_SENSE,
@@ -819,12 +839,12 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_prefix="Följande är flervalsfrågor (med svar).",
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=10,
+    num_few_shot_examples=5,
     max_generated_tokens=3,
 )
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
-    name="mmlu-de",
+    name="hellaswag-de",
     pretty_name="the German part of the truncated version of MMLU",
     huggingface_id="ScandEval/hellaswag-de-mini",
     task=COMMON_SENSE,
@@ -832,12 +852,12 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_prefix="Die folgenden Fragen sind Multiple-Choice-Fragen (mit Antworten).",
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=10,
+    num_few_shot_examples=5,
     max_generated_tokens=3,
 )
 
 HELLASWAG_NL_CONFIG = DatasetConfig(
-    name="mmlu-nl",
+    name="hellaswag-nl",
     pretty_name="the Dutch part of the truncated version of MMLU",
     huggingface_id="ScandEval/hellaswag-nl-mini",
     task=COMMON_SENSE,
@@ -845,7 +865,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_prefix="Hieronder staan meerkeuzevragen (met antwoorden).",
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    num_few_shot_examples=10,
+    num_few_shot_examples=5,
     max_generated_tokens=3,
 )
 

--- a/src/scripts/constants.py
+++ b/src/scripts/constants.py
@@ -1,0 +1,13 @@
+"""Constants used in the dataset creation scripts."""
+
+
+# Bounds on the size of texts in question answering datasets
+MIN_NUM_CHARS_IN_CONTEXT = 30
+MAX_NUM_CHARS_IN_CONTEXT = 5000
+MIN_NUM_CHARS_IN_QUESTION = 10
+MAX_NUM_CHARS_IN_QUESTION = 100
+
+
+# Bounds on the size of texts in summarisation datasets
+MIN_NUM_CHARS_IN_ARTICLE = 30
+MAX_NUM_CHARS_IN_ARTICLE = 6000

--- a/src/scripts/create_cnn_dailymail.py
+++ b/src/scripts/create_cnn_dailymail.py
@@ -24,6 +24,16 @@ def main():
     assert isinstance(val_df, pd.DataFrame)
     assert isinstance(test_df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = val_df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_cnn_dailymail.py
+++ b/src/scripts/create_cnn_dailymail.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -28,8 +29,8 @@ def main():
     train_lengths = train_df.text.str.len()
     val_lengths = val_df.text.str.len()
     test_lengths = test_df.text.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
     test_df = test_df[test_lengths.between(lower_bound, upper_bound)]

--- a/src/scripts/create_germanquad.py
+++ b/src/scripts/create_germanquad.py
@@ -8,6 +8,12 @@ from datasets.load import load_dataset
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -30,15 +36,11 @@ def main() -> None:
 
     # Only work with samples where the context is not very large or small
     lengths = df.context.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)]
 
     # Only work with samples where the question is not very large or small
     lengths = df.question.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION)]
 
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)

--- a/src/scripts/create_germanquad.py
+++ b/src/scripts/create_germanquad.py
@@ -28,6 +28,12 @@ def main() -> None:
     # Ensure that `df` is indeed a Pandas DataFrame
     assert isinstance(df, pd.DataFrame)
 
+    # Only work with samples where the context is not very large or small
+    lengths = df.context.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)
 

--- a/src/scripts/create_germanquad.py
+++ b/src/scripts/create_germanquad.py
@@ -34,6 +34,12 @@ def main() -> None:
     upper_bound = lengths.quantile(0.95)
     df = df[lengths.between(lower_bound, upper_bound)]
 
+    # Only work with samples where the question is not very large or small
+    lengths = df.question.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)
 

--- a/src/scripts/create_mlsum.py
+++ b/src/scripts/create_mlsum.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -29,8 +30,8 @@ def main():
     train_lengths = train_df.text.str.len()
     val_lengths = val_df.text.str.len()
     test_lengths = test_df.text.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
     test_df = test_df[test_lengths.between(lower_bound, upper_bound)]

--- a/src/scripts/create_mlsum.py
+++ b/src/scripts/create_mlsum.py
@@ -25,6 +25,16 @@ def main():
     assert isinstance(val_df, pd.DataFrame)
     assert isinstance(test_df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = val_df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_no_sammendrag.py
+++ b/src/scripts/create_no_sammendrag.py
@@ -20,6 +20,12 @@ def main():
     df = dataset.to_pandas()
     assert isinstance(df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    lengths = df.text.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_no_sammendrag.py
+++ b/src/scripts/create_no_sammendrag.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -22,8 +23,8 @@ def main():
 
     # Only work with samples where the text is not very large or small
     lengths = df.text.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     df = df[lengths.between(lower_bound, upper_bound)]
 
     # Create validation split

--- a/src/scripts/create_nordjylland_news.py
+++ b/src/scripts/create_nordjylland_news.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -26,8 +27,8 @@ def main():
     train_lengths = train_df.text.str.len()
     val_lengths = val_df.text.str.len()
     test_lengths = test_df.text.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
     test_df = test_df[test_lengths.between(lower_bound, upper_bound)]

--- a/src/scripts/create_nordjylland_news.py
+++ b/src/scripts/create_nordjylland_news.py
@@ -22,6 +22,16 @@ def main():
     assert isinstance(val_df, pd.DataFrame)
     assert isinstance(test_df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = val_df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_norquad.py
+++ b/src/scripts/create_norquad.py
@@ -59,6 +59,12 @@ def main() -> None:
     df = pd.concat([train_df, val_df, test_df])
     df.reset_index(drop=True, inplace=True)
 
+    # Only work with samples where the context is not very large or small
+    lengths = df.context.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)
 

--- a/src/scripts/create_norquad.py
+++ b/src/scripts/create_norquad.py
@@ -65,6 +65,12 @@ def main() -> None:
     upper_bound = lengths.quantile(0.95)
     df = df[lengths.between(lower_bound, upper_bound)]
 
+    # Only work with samples where the question is not very large or small
+    lengths = df.question.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)
 

--- a/src/scripts/create_norquad.py
+++ b/src/scripts/create_norquad.py
@@ -7,6 +7,12 @@ from datasets.dataset_dict import DatasetDict
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -61,15 +67,11 @@ def main() -> None:
 
     # Only work with samples where the context is not very large or small
     lengths = df.context.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)]
 
     # Only work with samples where the question is not very large or small
     lengths = df.question.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION)]
 
     # Ensure that the `id` column is a string
     df["id"] = df["id"].astype(str)

--- a/src/scripts/create_nqii.py
+++ b/src/scripts/create_nqii.py
@@ -36,6 +36,12 @@ def main() -> None:
     upper_bound = lengths.quantile(0.95)
     df = df[lengths.between(lower_bound, upper_bound)]
 
+    # Only work with samples where the question is not very large or small
+    lengths = df.question.str.len()
+    lower_bound = lengths.quantile(0.03)
+    upper_bound = lengths.quantile(0.97)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     has_answer: pd.Series = df.answers.map(
         lambda dct: len(dct["text"]) > 0 and dct["text"][0] != ""

--- a/src/scripts/create_nqii.py
+++ b/src/scripts/create_nqii.py
@@ -8,6 +8,12 @@ from datasets.load import load_dataset
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -32,15 +38,11 @@ def main() -> None:
 
     # Only work with samples where the context is not very large or small
     lengths = df.context.str.len()
-    lower_bound = lengths.quantile(0.05)
-    upper_bound = lengths.quantile(0.95)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)]
 
     # Only work with samples where the question is not very large or small
     lengths = df.question.str.len()
-    lower_bound = lengths.quantile(0.03)
-    upper_bound = lengths.quantile(0.97)
-    df = df[lengths.between(lower_bound, upper_bound)]
+    df = df[lengths.between(MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION)]
 
     # Extract information on which examples contain an answer
     has_answer: pd.Series = df.answers.map(

--- a/src/scripts/create_nqii.py
+++ b/src/scripts/create_nqii.py
@@ -30,6 +30,12 @@ def main() -> None:
     # Ensure that `df` is indeed a Pandas DataFrame
     assert isinstance(df, pd.DataFrame)
 
+    # Only work with samples where the context is not very large or small
+    lengths = df.context.str.len()
+    lower_bound = lengths.quantile(0.05)
+    upper_bound = lengths.quantile(0.95)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     has_answer: pd.Series = df.answers.map(
         lambda dct: len(dct["text"]) > 0 and dct["text"][0] != ""

--- a/src/scripts/create_rrn.py
+++ b/src/scripts/create_rrn.py
@@ -22,6 +22,12 @@ def main():
 
     df.dropna(subset=["text", "target_text"], inplace=True)
 
+    # Only work with samples where the text is not very large or small
+    lengths = df.text.str.len()
+    lower_bound = lengths.quantile(0.01)
+    upper_bound = lengths.quantile(0.99)
+    df = df[lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_rrn.py
+++ b/src/scripts/create_rrn.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -24,8 +25,8 @@ def main():
 
     # Only work with samples where the text is not very large or small
     lengths = df.text.str.len()
-    lower_bound = lengths.quantile(0.01)
-    upper_bound = lengths.quantile(0.99)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     df = df[lengths.between(lower_bound, upper_bound)]
 
     # Create validation split

--- a/src/scripts/create_scandiqa.py
+++ b/src/scripts/create_scandiqa.py
@@ -8,6 +8,12 @@ from datasets.load import load_dataset
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -34,15 +40,13 @@ def main() -> None:
 
         # Only work with samples where the context is not very large or small
         lengths = df.context.str.len()
-        lower_bound = lengths.quantile(0.05)
-        upper_bound = lengths.quantile(0.95)
-        df = df[lengths.between(lower_bound, upper_bound)]
+        df = df[lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)]
 
         # Only work with samples where the context is not very large or small
         lengths = df.question.str.len()
-        lower_bound = lengths.quantile(0.05)
-        upper_bound = lengths.quantile(0.95)
-        df_with_no_outliers = df[lengths.between(lower_bound, upper_bound)]
+        df_with_no_outliers = df[
+            lengths.between(MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION)
+        ]
 
         # Only work with the questions having answers in the context
         has_answer: pd.Series = df_with_no_outliers.answers.map(

--- a/src/scripts/create_scandiqa.py
+++ b/src/scripts/create_scandiqa.py
@@ -36,6 +36,12 @@ def main() -> None:
         lengths = df.context.str.len()
         lower_bound = lengths.quantile(0.05)
         upper_bound = lengths.quantile(0.95)
+        df = df[lengths.between(lower_bound, upper_bound)]
+
+        # Only work with samples where the context is not very large or small
+        lengths = df.question.str.len()
+        lower_bound = lengths.quantile(0.05)
+        upper_bound = lengths.quantile(0.95)
         df_with_no_outliers = df[lengths.between(lower_bound, upper_bound)]
 
         # Only work with the questions having answers in the context

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -31,6 +31,14 @@ def main() -> None:
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
 
+    # Only work with samples where the question is not very large or small
+    train_question_lengths = train_df.question.str.len()
+    valtest_question_lengths = valtest_df.question.str.len()
+    lower_bound = train_question_lengths.quantile(0.05)
+    upper_bound = train_question_lengths.quantile(0.95)
+    train_df = train_df[train_question_lengths.between(lower_bound, upper_bound)]
+    valtest_df = valtest_df[valtest_question_lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:
         return len(example["text"]) > 0 and example["text"][0] != ""

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -23,6 +23,14 @@ def main() -> None:
     assert isinstance(train_df, pd.DataFrame)
     assert isinstance(valtest_df, pd.DataFrame)
 
+    # Only work with samples where the context is not very large or small
+    train_lengths = train_df.context.str.len()
+    valtest_lengths = valtest_df.context.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:
         return len(example["text"]) > 0 and example["text"][0] != ""

--- a/src/scripts/create_squad.py
+++ b/src/scripts/create_squad.py
@@ -7,6 +7,12 @@ from datasets.load import load_dataset
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -26,18 +32,26 @@ def main() -> None:
     # Only work with samples where the context is not very large or small
     train_lengths = train_df.context.str.len()
     valtest_lengths = valtest_df.context.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
-    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
-    valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
+    train_df = train_df[
+        train_lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)
+    ]
+    valtest_df = valtest_df[
+        valtest_lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)
+    ]
 
     # Only work with samples where the question is not very large or small
     train_question_lengths = train_df.question.str.len()
     valtest_question_lengths = valtest_df.question.str.len()
-    lower_bound = train_question_lengths.quantile(0.05)
-    upper_bound = train_question_lengths.quantile(0.95)
-    train_df = train_df[train_question_lengths.between(lower_bound, upper_bound)]
-    valtest_df = valtest_df[valtest_question_lengths.between(lower_bound, upper_bound)]
+    train_df = train_df[
+        train_question_lengths.between(
+            MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION
+        )
+    ]
+    valtest_df = valtest_df[
+        valtest_question_lengths.between(
+            MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION
+        )
+    ]
 
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:

--- a/src/scripts/create_squad_nl.py
+++ b/src/scripts/create_squad_nl.py
@@ -42,6 +42,14 @@ def main() -> None:
     assert isinstance(train_df, pd.DataFrame)
     assert isinstance(valtest_df, pd.DataFrame)
 
+    # Only work with samples where the context is not very large or small
+    train_lengths = train_df.context.str.len()
+    valtest_lengths = valtest_df.context.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:
         return len(example["answer_start"]) > 0 and example["answer_start"][0] >= 0
@@ -71,7 +79,6 @@ def main() -> None:
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)
     train_df = train_df.reset_index(drop=True)
-    breakpoint()
 
     # Collect datasets in a dataset dictionary
     dataset = DatasetDict(

--- a/src/scripts/create_squad_nl.py
+++ b/src/scripts/create_squad_nl.py
@@ -50,6 +50,14 @@ def main() -> None:
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
 
+    # Only work with samples where the question is not very large or small
+    train_question_lengths = train_df.question.str.len()
+    valtest_question_lengths = valtest_df.question.str.len()
+    lower_bound = train_question_lengths.quantile(0.05)
+    upper_bound = train_question_lengths.quantile(0.95)
+    train_df = train_df[train_question_lengths.between(lower_bound, upper_bound)]
+    valtest_df = valtest_df[valtest_question_lengths.between(lower_bound, upper_bound)]
+
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:
         return len(example["answer_start"]) > 0 and example["answer_start"][0] >= 0

--- a/src/scripts/create_squad_nl.py
+++ b/src/scripts/create_squad_nl.py
@@ -7,6 +7,12 @@ from datasets.load import load_dataset
 from datasets.splits import Split
 from huggingface_hub.hf_api import HfApi
 from requests.exceptions import HTTPError
+from scripts.constants import (
+    MAX_NUM_CHARS_IN_CONTEXT,
+    MAX_NUM_CHARS_IN_QUESTION,
+    MIN_NUM_CHARS_IN_CONTEXT,
+    MIN_NUM_CHARS_IN_QUESTION,
+)
 
 
 def main() -> None:
@@ -45,18 +51,26 @@ def main() -> None:
     # Only work with samples where the context is not very large or small
     train_lengths = train_df.context.str.len()
     valtest_lengths = valtest_df.context.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
-    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
-    valtest_df = valtest_df[valtest_lengths.between(lower_bound, upper_bound)]
+    train_df = train_df[
+        train_lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)
+    ]
+    valtest_df = valtest_df[
+        valtest_lengths.between(MIN_NUM_CHARS_IN_CONTEXT, MAX_NUM_CHARS_IN_CONTEXT)
+    ]
 
     # Only work with samples where the question is not very large or small
     train_question_lengths = train_df.question.str.len()
     valtest_question_lengths = valtest_df.question.str.len()
-    lower_bound = train_question_lengths.quantile(0.05)
-    upper_bound = train_question_lengths.quantile(0.95)
-    train_df = train_df[train_question_lengths.between(lower_bound, upper_bound)]
-    valtest_df = valtest_df[valtest_question_lengths.between(lower_bound, upper_bound)]
+    train_df = train_df[
+        train_question_lengths.between(
+            MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION
+        )
+    ]
+    valtest_df = valtest_df[
+        valtest_question_lengths.between(
+            MIN_NUM_CHARS_IN_QUESTION, MAX_NUM_CHARS_IN_QUESTION
+        )
+    ]
 
     # Extract information on which examples contain an answer
     def has_answer(example: dict) -> bool:

--- a/src/scripts/create_swedn.py
+++ b/src/scripts/create_swedn.py
@@ -24,6 +24,16 @@ def main():
     assert isinstance(val_df, pd.DataFrame)
     assert isinstance(test_df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = val_df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_swedn.py
+++ b/src/scripts/create_swedn.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -28,8 +29,8 @@ def main():
     train_lengths = train_df.text.str.len()
     val_lengths = val_df.text.str.len()
     test_lengths = test_df.text.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
     test_df = test_df[test_lengths.between(lower_bound, upper_bound)]

--- a/src/scripts/create_wiki_lingua_nl.py
+++ b/src/scripts/create_wiki_lingua_nl.py
@@ -24,6 +24,16 @@ def main():
     assert isinstance(val_df, pd.DataFrame)
     assert isinstance(test_df, pd.DataFrame)
 
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = train_lengths.quantile(0.05)
+    upper_bound = train_lengths.quantile(0.95)
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
     # Create validation split
     val_size = 256
     val_df = val_df.sample(n=val_size, random_state=4242)

--- a/src/scripts/create_wiki_lingua_nl.py
+++ b/src/scripts/create_wiki_lingua_nl.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datasets import Dataset, DatasetDict, Split, load_dataset
 from huggingface_hub import HfApi
 from requests import HTTPError
+from scripts.constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
 
 
 def main():
@@ -28,8 +29,8 @@ def main():
     train_lengths = train_df.text.str.len()
     val_lengths = val_df.text.str.len()
     test_lengths = test_df.text.str.len()
-    lower_bound = train_lengths.quantile(0.05)
-    upper_bound = train_lengths.quantile(0.95)
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
     train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
     val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
     test_df = test_df[test_lengths.between(lower_bound, upper_bound)]


### PR DESCRIPTION
## Summary
Some of the samples in our datasets were excessively long or excessively short. Especially the long ones caused problems with OOM errors, without them adding anything significant to the dataset. Since this is not a long-context benchmark per se, I've removed the excessively long top-5% samples from datasets, as well as adjusted the number of few-shot examples to ensure that the samples are at most ~3000 tokens long.

## Updates to Change Log
### Changed
- Samples with excessively short or long texts have been removed.
- Adjusted number of few-shot examples in datasets to ensure that the resulting prompt is at most ~3000 tokens long.