### PR TITLE
Feat/optimize cache memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Removed some vLLM logging.
+- Only require generative models to output logprobs if the dataset is of a task that
+  requires it. This caused the benchmarking to use excessive memory when benchmarking
+  datasets that require long generative outputs, such as NER.
 
 
 ## [v9.0.0] - 2024-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   caching.
 
 ### Fixed
-- Removed some vLLM logging.
 - Only require generative models to output logprobs if the dataset is of a task that
   requires it. This caused the benchmarking to use excessive memory when benchmarking
   datasets that require long generative outputs, such as NER.
+
+### Removed
+- Removed some vLLM logging.
 
 
 ## [v9.0.0] - 2024-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   these help reduce the memory usage of the model output cache.
 - Optimised cache saving/loading a bit, making the waiting time in between iterations
   slightly shorter.
-- Removed indents in model output cache JSON files, to reduce disk space used.
 - Removes the model output cache for a (model, dataset) combination when the
-  benchmarking of the model on the dataset finishes successfully.
+  benchmarking of the model on the dataset finishes successfully. Also removed indents
+  in model output cache JSON files. Both of these help reducing the disk space used on
+  caching.
 
 ### Fixed
 - Removed some vLLM logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Optimized memory usage of model output cache by only storing the log probabilities of
+- Now only stores the log probabilities of
   generated tokens when the generation length is less than 8 tokens, rather than less
-  than 50. Also now keeps separate caches for each (model, dataset) combination, where
+  than 50. ow keeps separate caches for each (model, dataset) combination, where
   it previously had a single cache for each model.
+- Optimised cache saving/loading a bit, making the waiting time in between iterations
+  slightly shorter.
 
 ### Fixed
 - Removed some vLLM logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- Optimized memory usage of model output cache by only storing the log probabilities of
+  generated tokens when the generation length is less than 8 tokens, rather than less
+  than 50. Also now keeps separate caches for each (model, dataset) combination, where
+  it previously had a single cache for each model.
+
 ### Fixed
 - Removed some vLLM logging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Optimised cache saving/loading a bit, making the waiting time in between iterations
   slightly shorter.
 - Removed indents in model output cache JSON files, to reduce disk space used.
+- Removes the model output cache for a (model, dataset) combination when the
+  benchmarking of the model on the dataset finishes successfully.
 
 ### Fixed
 - Removed some vLLM logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Now only stores the log probabilities of
-  generated tokens when the generation length is less than 8 tokens, rather than less
-  than 50. ow keeps separate caches for each (model, dataset) combination, where
-  it previously had a single cache for each model.
+- Now only stores the top-10 log probabilities of generated tokens when the generation
+  length is less than 8 tokens. Also now keeps separate caches for each (model,
+  dataset) combination, where it previously had a single cache for each model. Both of
+  these help reduce the memory usage of the model output cache.
 - Optimised cache saving/loading a bit, making the waiting time in between iterations
   slightly shorter.
+- Removed indents in model output cache JSON files, to reduce disk space used.
 
 ### Fixed
 - Removed some vLLM logging.

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -417,7 +417,7 @@ class BenchmarkDataset(ABC):
         )
 
         # Prepare the train and validation datasets
-        with tqdm(total=12, desc="Preprocessing data splits", leave=False) as pbar:
+        with tqdm(total=12, desc="Preprocessing data splits") as pbar:
             # When evaluating generative models we only need the test split, so
             # there's no need to prepare the train split
             try:

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -2,6 +2,7 @@
 
 
 import logging
+import multiprocessing as mp
 import sys
 from abc import ABC, abstractmethod
 from functools import partial
@@ -119,24 +120,32 @@ class BenchmarkDataset(ABC):
             benchmark_config=self.benchmark_config,
         )
 
+        benchmarking_generative_model = model_is_generative(model=model)
+
         # This happens when a local model is used, as we cannot fetch the model
         # metadata. Note that this is only the case if the model type is not any of the
         # ones hardcoded in `local.py`
         if model_config.task == "unknown":
-            if model_is_generative(model=model):
+            if benchmarking_generative_model:
                 model_config.task = GENERATIVE_MODEL_TASKS[0]
             else:
                 model_config.task = "fill-mask"
 
         metadata_dict = self._get_metadata(
-            model_id=model_id, model=model, tokenizer=tokenizer
+            model_id=model_id,
+            model=model,
+            tokenizer=tokenizer,
+            benchmarking_generative_model=benchmarking_generative_model,
         )
 
         # Set variable with number of iterations
         num_iter = 2 if hasattr(sys, "_called_from_test") else 10
 
         if self.dataset_config.task != SPEED:
-            train, val, tests = self._load_data(num_iter=num_iter, rng=rng)
+            train, val, tests = self._load_data(
+                num_iter=num_iter,
+                rng=rng,
+            )
             prepared_train, prepared_val, prepared_tests = self._load_prepared_data(
                 train=train,
                 val=val,
@@ -144,7 +153,7 @@ class BenchmarkDataset(ABC):
                 model_config=model_config,
                 hf_model_config=model.config,
                 tokenizer=tokenizer,
-                generative_model=model_is_generative(model=model),
+                benchmarking_generative_model=benchmarking_generative_model,
             )
 
         # Set up progress bar
@@ -165,7 +174,7 @@ class BenchmarkDataset(ABC):
                 dataset_config=self.dataset_config,
                 benchmark_config=self.benchmark_config,
             )
-        elif model_is_generative(model=model):
+        elif benchmarking_generative_model:
             scores = generate(
                 itr=itr,
                 prepared_train=prepared_train,
@@ -214,6 +223,7 @@ class BenchmarkDataset(ABC):
         model_id: str,
         model: PreTrainedModel | GenerativeModel,
         tokenizer: Tokenizer,
+        benchmarking_generative_model: bool,
     ) -> dict[str, int]:
         """Get metadata about the model.
 
@@ -224,6 +234,8 @@ class BenchmarkDataset(ABC):
                 The model to get metadata about.
             tokenizer:
                 The tokenizer to get metadata about.
+            benchmarking_generative_model:
+                Whether the model is a generative model.
 
         Returns:
             A dictionary containing metadata about the model, with the keys being the
@@ -263,7 +275,7 @@ class BenchmarkDataset(ABC):
         # length from the maximum length to allow it to keep generating. But for the
         # model metadata we want to know the maximum length, so we add the generation
         # length back on here
-        if max_seq_length >= 0 and model_is_generative(model=model):
+        if max_seq_length >= 0 and benchmarking_generative_model:
             max_seq_length += self.dataset_config.max_generated_tokens
 
             # If the model is an OpenAI chat model then we add on 7 extra tokens, as
@@ -284,7 +296,7 @@ class BenchmarkDataset(ABC):
             num_model_parameters=num_params,
             max_sequence_length=max_seq_length,
             vocabulary_size=vocab_size,
-            few_shot=model_is_generative(model=model),
+            few_shot=benchmarking_generative_model,
             validation_split=self.benchmark_config.only_validation_split,
         )
 
@@ -307,9 +319,7 @@ class BenchmarkDataset(ABC):
         return metadata_dict
 
     def _load_data(
-        self,
-        num_iter: int,
-        rng: np.random.Generator,
+        self, num_iter: int, rng: np.random.Generator
     ) -> tuple[Dataset, Dataset, list[Dataset]]:
         """Load the raw bootstrapped datasets.
 
@@ -379,7 +389,7 @@ class BenchmarkDataset(ABC):
         model_config: ModelConfig,
         hf_model_config: PretrainedConfig,
         tokenizer: Tokenizer,
-        generative_model: bool,
+        benchmarking_generative_model: bool,
     ) -> tuple[Dataset, Dataset, list[Dataset]]:
         """Load the data and prepare it for training.
 
@@ -396,7 +406,7 @@ class BenchmarkDataset(ABC):
                 The Hugging Face model configuration.
             tokenizer:
                 The tokenizer.
-            generative_model:
+            benchmarking_generative_model:
                 Whether the model is a generative model.
 
         Returns:
@@ -407,7 +417,7 @@ class BenchmarkDataset(ABC):
             hf_model_config=hf_model_config,
             model_config=model_config,
             tokenizer=tokenizer,
-            generative_model=generative_model,
+            generative_model=benchmarking_generative_model,
         )
 
         # Prepare the train and validation datasets
@@ -416,7 +426,7 @@ class BenchmarkDataset(ABC):
             # there's no need to prepare the train split
             try:
                 prepared_train = train
-                if not generative_model:
+                if not benchmarking_generative_model:
                     prepared_train = self._preprocess_data(
                         train, split="train", **preprocess_params
                     )
@@ -430,7 +440,7 @@ class BenchmarkDataset(ABC):
             # there's no need to prepare the validation split
             try:
                 prepared_val = val
-                if not generative_model:
+                if not benchmarking_generative_model:
                     prepared_val = self._preprocess_data(
                         val, split="val", **preprocess_params
                     )
@@ -443,7 +453,7 @@ class BenchmarkDataset(ABC):
             try:
                 prepared_tests: list[Dataset] = list()
                 for itr_idx, test in enumerate(tests):
-                    if generative_model:
+                    if benchmarking_generative_model:
                         itr_seed = 4242 + itr_idx
                         few_shot_examples = self._extract_few_shot_examples(
                             train_dataset=train, random_seed=itr_seed
@@ -455,6 +465,24 @@ class BenchmarkDataset(ABC):
                         test = test.map(
                             few_shot_fn, batched=True, load_from_cache_file=False
                         )
+
+                        # If we are benchmarking a generative model then we want to
+                        # encode and decode all the texts in the test dataset, to
+                        # ensure that the model output cache has the correct input
+                        # prompts in it
+                        test = test.map(
+                            lambda example: dict(
+                                text=tokenizer.decode(
+                                    tokenizer(
+                                        text=example["text"],
+                                        truncation=True,
+                                    ).input_ids,
+                                    skip_special_tokens=True,
+                                )
+                            ),
+                            num_proc=mp.cpu_count(),
+                        )
+
                     prepared_test = self._preprocess_data(
                         test, split="test", **preprocess_params
                     )

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -475,6 +475,7 @@ class BenchmarkDataset(ABC):
                                 ),
                             ),
                             batched=True,
+                            load_from_cache_file=False,
                         )
 
                     prepared_tests.append(prepared_test)

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -468,6 +468,18 @@ class BenchmarkDataset(ABC):
                     prepared_test = self._preprocess_data(
                         test, split="test", **preprocess_params
                     )
+
+                    if benchmarking_generative_model:
+                        prepared_test = prepared_test.map(
+                            lambda examples: dict(
+                                text=tokenizer.batch_decode(
+                                    sequences=examples["input_ids"],
+                                    skip_special_tokens=True,
+                                ),
+                            ),
+                            batched=True,
+                        )
+
                     prepared_tests.append(prepared_test)
                     pbar.update(1)
             except ValueError:

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -141,10 +141,7 @@ class BenchmarkDataset(ABC):
         num_iter = 2 if hasattr(sys, "_called_from_test") else 10
 
         if self.dataset_config.task != SPEED:
-            train, val, tests = self._load_data(
-                num_iter=num_iter,
-                rng=rng,
-            )
+            train, val, tests = self._load_data(num_iter=num_iter, rng=rng)
             prepared_train, prepared_val, prepared_tests = self._load_prepared_data(
                 train=train,
                 val=val,

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -112,6 +112,7 @@ class BenchmarkDataset(ABC):
         # weights
         rng = enforce_reproducibility(framework=model_config.framework)
 
+        logger.info("Loading model and tokenizer...")
         tokenizer, model = load_model(
             model_config=model_config,
             dataset_config=self.dataset_config,

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -2,7 +2,6 @@
 
 
 import logging
-import multiprocessing as mp
 import sys
 from abc import ABC, abstractmethod
 from functools import partial
@@ -464,23 +463,6 @@ class BenchmarkDataset(ABC):
                         )
                         test = test.map(
                             few_shot_fn, batched=True, load_from_cache_file=False
-                        )
-
-                        # If we are benchmarking a generative model then we want to
-                        # encode and decode all the texts in the test dataset, to
-                        # ensure that the model output cache has the correct input
-                        # prompts in it
-                        test = test.map(
-                            lambda example: dict(
-                                text=tokenizer.decode(
-                                    tokenizer(
-                                        text=example["text"],
-                                        truncation=True,
-                                    ).input_ids,
-                                    skip_special_tokens=True,
-                                )
-                            ),
-                            num_proc=mp.cpu_count(),
                         )
 
                     prepared_test = self._preprocess_data(

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -313,7 +313,8 @@ class Benchmarker:
                 if self.benchmark_config.save_results:
                     record.append_to_results(results_path=self.results_path)
 
-            self.clear_model_cache()
+            if self.benchmark_config.clear_model_cache:
+                self.clear_model_cache()
 
         return self.benchmark_results
 
@@ -323,14 +324,13 @@ class Benchmarker:
         Note that this will not remove the stored completions, and it will only clear
         the cache if `clear_model_cache` is set to True.
         """
-        if self.benchmark_config.clear_model_cache:
-            model_cache_path = Path(self.benchmark_config.cache_dir) / "model_cache"
-            model_cache_path.mkdir(parents=True, exist_ok=True)
-            for model_dir in model_cache_path.iterdir():
-                if model_dir.is_dir():
-                    for sub_model_dir in model_dir.iterdir():
-                        if sub_model_dir.is_dir():
-                            rmtree(sub_model_dir)
+        model_cache_path = Path(self.benchmark_config.cache_dir) / "model_cache"
+        model_cache_path.mkdir(parents=True, exist_ok=True)
+        for model_dir in model_cache_path.iterdir():
+            if model_dir.is_dir():
+                for sub_model_dir in model_dir.iterdir():
+                    if sub_model_dir.is_dir():
+                        rmtree(sub_model_dir)
 
     def _prepare_model_ids(
         self,

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -291,8 +291,7 @@ class Benchmarker:
 
                 # Benchmark a single model on a single dataset
                 record = self._benchmark_single(
-                    dataset_config=dataset_config,
-                    model_id=m_id,
+                    dataset_config=dataset_config, model_id=m_id
                 )
 
                 # If the benchmark was unsuccessful then skip
@@ -411,9 +410,7 @@ class Benchmarker:
         return dataset_configs
 
     def _benchmark_single(
-        self,
-        dataset_config: DatasetConfig,
-        model_id: str,
+        self, dataset_config: DatasetConfig, model_id: str
     ) -> BenchmarkResult | dict[str, str]:
         """Benchmark a single model on a single dataset.
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -186,9 +186,9 @@ def generate_single_iteration(
     # that that cache is deleted before the next test, to ensure that the tests are
     # independent of each other
     if not hasattr(sys, "_called_from_test"):
-        cache_name = "model_outputs.json"
+        cache_name = f"{dataset_config.name}-model-outputs.json"
     else:
-        cache_name = "model_outputs_test.json"
+        cache_name = f"{dataset_config.name}-model-outputs-test.json"
         (model_cache_dir / cache_name).unlink(missing_ok=True)
 
     cache = ModelCache(

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -425,6 +425,7 @@ def generate_batch(
 
     # Hugging Face models include the input in the generated sequence, so we
     # need to remove it in that case
+    inputs = inputs.detach().cpu()
     if torch.equal(model_output.sequences[:, : inputs.shape[1]], inputs):
         model_output.sequences = model_output.sequences[:, inputs.shape[1] :]
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -460,7 +460,7 @@ def extract_raw_predictions(
         tokenizer.decode(completion_ids.tolist(), skip_special_tokens=True)
         .split("\n\n")[0]
         .strip("\n ")
-        for completion_ids in generated_sequences
+        for completion_ids in generated_sequences.long()
     ]
     return raw_predictions
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -267,6 +267,7 @@ def generate_single_iteration(
                 generation_config=generation_config,
                 extract_labels_fn=extract_labels_fn,
             )
+            logger.debug(f"Adding batch {batch_idx} to cache...")  # TEMP
             cache.add_to_cache(
                 model_input=batch["input_ids"],
                 model_output=model_output,

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -431,11 +431,13 @@ def generate_batch(
 
     # Hugging Face models include the input in the generated sequence, so we
     # need to remove it in that case
+    logger.debug("Removing prefix outputs...")  # TEMP
     if torch.equal(model_output.sequences[:, : inputs.shape[1]], inputs):
         model_output.sequences = model_output.sequences[:, inputs.shape[1] :]
 
     # Extract the labels from the model output and store them for metric
     # computation later
+    logger.debug("Extracting labels from model output...")  # TEMP
     batch_start = batch_idx * batch_size
     batch_end = (batch_idx + 1) * batch_size
     input_batch = non_cached_dataset[batch_start:batch_end]

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -151,7 +151,7 @@ def generate(
             clear_memory()
 
     # Delete the model output cache again
-    del cache
+    cache.remove()
 
     return scores
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -1,6 +1,5 @@
 """Functions related to text generation of models."""
 
-import json
 import logging
 import sys
 import warnings
@@ -80,14 +79,6 @@ def generate(
         iteration.
     """
     scores: dict[str, list[dict[str, float]]] = defaultdict(list)
-
-    # Create model output cache
-    model_cache_dir = Path(model_config.model_cache_dir)
-    model_cache_dir.mkdir(parents=True, exist_ok=True)
-    cache_path = model_cache_dir / "model_outputs.json"
-    if not cache_path.exists():
-        with cache_path.open("w") as f:
-            json.dump(dict(), f)
 
     for idx in itr:
         prepared_test = prepared_tests[idx]

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -80,15 +80,16 @@ def generate(
     """
     scores: dict[str, list[dict[str, float]]] = defaultdict(list)
 
-    # Initialise the model output cache. If we are testing then we save the model
-    # outputs to a different cache and ensure that that cache is deleted before the
-    # next test, to ensure that the tests are independent of each other
+    # Set up the name of the model output cache. If we are testing then we save the
+    # model outputs to a different cache and ensure that that cache is deleted before
+    # the next test, to ensure that the tests are independent of each other
     model_cache_dir = Path(model_config.model_cache_dir)
     if not hasattr(sys, "_called_from_test"):
         cache_name = f"{dataset_config.name}-model-outputs.json"
     else:
         cache_name = f"{dataset_config.name}-model-outputs-test.json"
         (model_cache_dir / cache_name).unlink(missing_ok=True)
+
     cache = ModelCache(
         model_cache_dir=model_cache_dir,
         cache_name=cache_name,
@@ -148,6 +149,9 @@ def generate(
             logger.debug(f"Train scores for iteration {idx}: {train_scores}")
             scores["train"].append(train_scores)
             clear_memory()
+
+    # Delete the model output cache again
+    del cache
 
     return scores
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -150,9 +150,7 @@ def generate(
             scores["train"].append(train_scores)
             clear_memory()
 
-    # Delete the model output cache again
     cache.remove()
-
     return scores
 
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -275,15 +275,18 @@ def generate_single_iteration(
             all_preds.extend(extracted_labels)
 
         # Store the cache to disk
+        logger.debug("Saving cache to disk...")  # TEMP
         cache.save()
 
     # Fetch the cached predictions for the cached examples
     if len(cached_dataset) > 0:
+        logger.debug("Loading cached model outputs...")  # TEMP
         model_output = load_cached_model_outputs(
             cached_dataset=cached_dataset,
             cache=cache,
             tokenizer=tokenizer,
         )
+        logger.debug("Extracting labels from cached model outputs...")  # TEMP
         extracted_labels = extract_labels_fn(
             input_batch=cached_dataset,
             model_output=model_output,
@@ -308,11 +311,13 @@ def generate_single_iteration(
             "The dataset must have either a 'label', 'labels', or 'target_text' column"
         )
 
+    logger.debug("Computing metrics...")  # TEMP
     itr_scores: dict[str, float] = compute_metrics(
         model_outputs_and_labels=(all_preds, ground_truth),
         id2label=dataset_config.id2label,
     )
 
+    logger.debug("Finished iteration")  # TEMP
     return itr_scores
 
 

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -226,10 +226,10 @@ def load_cached_model_outputs(
     # encode and decode all the texts in the test dataset, to
     # ensure that the model output cache has the correct input
     # prompts in it
-    cached_prompts = tokenizer.decode(
-        token_ids=[example["input_ids"] for example in cached_dataset],
-        skip_special_tokens=True,
-    )
+    cached_prompts = [
+        tokenizer.decode(token_ids=example["input_ids"], skip_special_tokens=True)
+        for example in cached_dataset
+    ]
 
     # Load the raw model outputs from the cache
     cached_model_outputs: list[GenerativeModelOutput] = [

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -109,6 +109,11 @@ class ModelCache:
         """
         self.cache[key] = value
 
+    def __del__(self) -> None:
+        """Remove the cache from memory and delete it from disk."""
+        self.cache_path.unlink()
+        del self.cache
+
     def cached_texts(self) -> list[str]:
         """Return the text inputs indexed in the cache."""
         return [key for key in self.cache.keys()]

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -222,18 +222,9 @@ def load_cached_model_outputs(
     Returns:
         The model output containing the cached sequences.
     """
-    # If we are benchmarking a generative model then we want to
-    # encode and decode all the texts in the test dataset, to
-    # ensure that the model output cache has the correct input
-    # prompts in it
-    cached_prompts = [
-        tokenizer.decode(token_ids=example["input_ids"], skip_special_tokens=True)
-        for example in cached_dataset
-    ]
-
     # Load the raw model outputs from the cache
     cached_model_outputs: list[GenerativeModelOutput] = [
-        cache[prompt] for prompt in cached_prompts
+        cache[prompt] for prompt in cached_dataset["text"]
     ]
 
     # Tokenize the cached sequences

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -60,11 +60,10 @@ class ModelCache:
         self.model_cache_dir = model_cache_dir
         self.model_cache_dir.mkdir(parents=True, exist_ok=True)
         self.cache_path = self.model_cache_dir / cache_name
-        self.cache: dict[str, GenerativeModelOutput] = self.load()
         self.max_generated_tokens = max_generated_tokens
 
-    def load(self) -> dict[str, GenerativeModelOutput]:
-        """Load and return the model output cache."""
+    def load(self) -> None:
+        """Load the model output cache."""
         if not self.cache_path.exists():
             with self.cache_path.open("w") as f:
                 json.dump(dict(), f)
@@ -75,7 +74,8 @@ class ModelCache:
         cache: dict[str, GenerativeModelOutput] = dict()
         for key in json_cache:
             cache[key] = GenerativeModelOutput(**json_cache[key])
-        return cache
+
+        self.cache = cache
 
     def save(self) -> None:
         """Save the model output cache to disk."""

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -127,12 +127,19 @@ class ModelCache:
             tokenizer:
                 The tokenizer used to generate the tokens.
         """
+        model_input = model_input.detach().cpu()
+
         # Extract the scores from the model output, to be cached. We only store the
-        # indices of the top 100 scores, to save space. Further, we only store the
-        # scores if the generated sequence is shorter than the maximum length
-        store_scores = "scores" in model_output and self.max_generated_tokens < 50
+        # indices of the top scores, to save space. Further, we only store the scores
+        # if the generated sequence is shorter than the maximum length
+        store_scores = "scores" in model_output and self.max_generated_tokens < 8
         if store_scores:
-            scores = torch.stack(model_output.scores, dim=1)
+            scores = torch.stack(
+                tensors=[
+                    score_tensor.detach().cpu() for score_tensor in model_output.scores
+                ],
+                dim=1,
+            )
             top_scores = torch.topk(scores, k=100)
 
         # Store the generated sequences in the cache, one by one

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -219,21 +219,6 @@ def load_cached_model_outputs(
     Returns:
         The model output containing the cached sequences.
     """
-    # Encode and decode the samples in the cached dataset, to ensure that the cached
-    # sequences are tokenized in the same way as the model outputs
-    cached_dataset = cached_dataset.map(
-        lambda example: dict(
-            text=tokenizer.decode(
-                tokenizer(
-                    text=example["text"],
-                    truncation=True,
-                    return_tensors="pt",
-                ).input_ids.squeeze(dim=0),
-                skip_special_tokens=True,
-            )
-        ),
-    )
-
     # Load the raw model outputs from the cache
     cached_model_outputs: list[GenerativeModelOutput] = [
         cache[example["text"]] for example in cached_dataset

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -109,7 +109,7 @@ class ModelCache:
         """
         self.cache[key] = value
 
-    def __del__(self) -> None:
+    def remove(self) -> None:
         """Remove the cache from memory and delete it from disk."""
         self.cache_path.unlink()
         del self.cache

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -222,9 +222,18 @@ def load_cached_model_outputs(
     Returns:
         The model output containing the cached sequences.
     """
+    # If we are benchmarking a generative model then we want to
+    # encode and decode all the texts in the test dataset, to
+    # ensure that the model output cache has the correct input
+    # prompts in it
+    cached_prompts = tokenizer.decode(
+        token_ids=[example["input_ids"] for example in cached_dataset],
+        skip_special_tokens=True,
+    )
+
     # Load the raw model outputs from the cache
     cached_model_outputs: list[GenerativeModelOutput] = [
-        cache[example["text"]] for example in cached_dataset
+        cache[prompt] for prompt in cached_prompts
     ]
 
     # Tokenize the cached sequences

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -84,7 +84,7 @@ class ModelCache:
             dumpable_cache[key] = asdict(value)
 
         with self.cache_path.open("w") as f:
-            json.dump(dumpable_cache, f, indent=4)
+            json.dump(dumpable_cache, f)
 
     def __getitem__(self, key: str) -> GenerativeModelOutput:
         """Get an item from the cache.
@@ -142,7 +142,7 @@ class ModelCache:
                 ],
                 dim=1,
             )
-            top_scores = torch.topk(scores, k=100)
+            top_scores = torch.topk(scores, k=10)
 
         # Store the generated sequences in the cache, one by one
         # TODO: This is a bit slow, should be optimized

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -322,6 +322,8 @@ class HFModelSetup:
                         except ImportError as e:
                             if "flash attention" in str(e).lower():
                                 raise FlashAttentionNotInstalled()
+                            else:
+                                raise e
                         except (KeyError, RuntimeError) as e:
                             if not model_kwargs["ignore_mismatched_sizes"]:
                                 logger.debug(

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -261,6 +261,14 @@ class HFModelSetup:
                     model_cache_dir=model_config.model_cache_dir,
                 )
             except ValueError as e:
+                # If the model is too large to fit on the GPU then we simply throw an
+                # informative error message
+                oom_error_message = "No available memory for the cache blocks"
+                if oom_error_message in str(e):
+                    raise InvalidBenchmark("The model is too large to load on the GPU.")
+
+                # Otherwise some other error occurred, and we log it and try to load
+                # the model with Hugging Face instead
                 use_vllm = False
                 logger.info(
                     "Failed to benchmark with vLLM - trying with the Hugging Face "

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -123,6 +123,20 @@ class OpenAITokenizer:
         ]
         return encoding.decode(tokens=token_ids)
 
+    def batch_decode(self, sequences: list[list[int]], **kwargs) -> list[str]:
+        """Decode batched token IDs.
+
+        Args:
+            sequences:
+                The token IDs to decode.
+            **kwargs:
+                Additional keyword arguments.
+
+        Returns:
+            The decoded text.
+        """
+        return [self.decode(token_ids=sequence) for sequence in sequences]
+
     def encode(self, text: str | list[str] | list[int], **kwargs) -> list[int]:
         """Encode text.
 

--- a/src/scandeval/protocols.py
+++ b/src/scandeval/protocols.py
@@ -60,6 +60,20 @@ class Tokenizer(Protocol):
         """
         ...
 
+    def batch_decode(self, sequences: list[list[int]], **kwargs) -> list[str]:
+        """Decode a batch of token IDs.
+
+        Args:
+            sequences:
+                The token IDs to decode.
+            **kwargs:
+                Keyword arguments to pass to the tokenizer.
+
+        Returns:
+            The decoded strings.
+        """
+        ...
+
     def encode(self, text: str | list[str] | list[int], **kwargs) -> list[int]:
         """Encode one or more texts.
 

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -84,6 +84,7 @@ class QuestionAnswering(BenchmarkDataset):
                 batched=True,
                 batch_size=10,
                 remove_columns=cols_to_remove,
+                load_from_cache_file=False,
             )
 
         except NotImplementedError as e:

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -54,6 +54,11 @@ GENERATIVE_DATASET_SUPERTASKS = [
 ]
 
 
+SUPERTASKS_USING_LOGPROBS = [
+    "sequence-classification",
+]
+
+
 def create_model_cache_dir(cache_dir: str, model_id: str) -> str:
     """Create cache directory for a model.
 

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -157,6 +157,7 @@ class VLLMModel:
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)
+        breakpoint()
         logger.debug("Padding generated sequences...")  # TEMP
         output = torch.nn.utils.rnn.pad_sequence(
             sequences=[

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -129,7 +129,7 @@ class VLLMModel:
             repetition_penalty=generation_config.repetition_penalty,
             frequency_penalty=generation_config.repetition_penalty - 1.0,
             stop=stop_tokens,
-            logprobs=10,
+            logprobs=10 if generation_config.output_scores else None,
         )
 
         # The inputs are tokenised, so we decode them to get the original text, which

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -157,12 +157,10 @@ class VLLMModel:
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)
-        breakpoint()
         logger.debug("Padding generated sequences...")  # TEMP
         output = torch.nn.utils.rnn.pad_sequence(
             sequences=[
-                torch.LongTensor(output.outputs[0].token_ids).to(self.device)
-                for output in raw_outputs
+                torch.LongTensor(output.outputs[0].token_ids) for output in raw_outputs
             ],
             batch_first=True,
             padding_value=float(self.tokenizer.pad_token_id),
@@ -179,6 +177,7 @@ class VLLMModel:
                 max_seq_len = max(
                     len(raw_output.outputs[0].logprobs) for raw_output in raw_outputs
                 )
+                breakpoint()
                 scores = [
                     torch.full(size=(batch_size, vocab_size), fill_value=-1e9)
                     for _ in range(max_seq_len)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -129,7 +129,7 @@ class VLLMModel:
             repetition_penalty=generation_config.repetition_penalty,
             frequency_penalty=generation_config.repetition_penalty - 1.0,
             stop=stop_tokens,
-            logprobs=100,
+            logprobs=10,
         )
 
         # The inputs are tokenised, so we decode them to get the original text, which

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -157,6 +157,7 @@ class VLLMModel:
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)
+        logger.debug("Padding generated sequences...")  # TEMP
         output = torch.nn.utils.rnn.pad_sequence(
             sequences=[
                 torch.LongTensor(output.outputs[0].token_ids).to(self.device)
@@ -169,6 +170,7 @@ class VLLMModel:
         if generation_config.return_dict_in_generate:
             # Add logprobs scores to the output
             if generation_config.output_scores:
+                logger.debug("Adding logprobs to output...")  # TEMP
                 # Create a list with placeholder logprobs for every token generated.
                 # Each tensor in the list will be of shape (batch_size, vocab_size)
                 batch_size = len(raw_outputs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -157,7 +157,6 @@ class VLLMModel:
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)
-        logger.debug("Padding generated sequences...")  # TEMP
         output = torch.nn.utils.rnn.pad_sequence(
             sequences=[
                 torch.LongTensor(output.outputs[0].token_ids) for output in raw_outputs
@@ -169,7 +168,6 @@ class VLLMModel:
         if generation_config.return_dict_in_generate:
             # Add logprobs scores to the output
             if generation_config.output_scores:
-                logger.debug("Adding logprobs to output...")  # TEMP
                 # Create a list with placeholder logprobs for every token generated.
                 # Each tensor in the list will be of shape (batch_size, vocab_size)
                 batch_size = len(raw_outputs)
@@ -177,7 +175,6 @@ class VLLMModel:
                 max_seq_len = max(
                     len(raw_output.outputs[0].logprobs) for raw_output in raw_outputs
                 )
-                breakpoint()
                 scores = [
                     torch.full(size=(batch_size, vocab_size), fill_value=-1e9)
                     for _ in range(max_seq_len)
@@ -185,8 +182,7 @@ class VLLMModel:
 
                 # Fill in the logprobs for each generated token. The logprobs from the
                 # vLLM output only contain the logprobs for the top-k tokens, so we
-                # only fill in these and leave the rest as -1e9, corresponding to ~0%
-                # probability
+                # only fill in these and leave the rest at ~0% probability
                 for sample_idx, raw_output in enumerate(raw_outputs):
                     assert raw_output.outputs[0].logprobs is not None
                     seq_len = len(raw_output.outputs[0].logprobs)


### PR DESCRIPTION
## Summary
This PR is primarily reducing memory usage during benchmarking, as well as slightly reducing benchmarking speed and disk space use.

## Changelog Additions
### Changed
- Now only stores the top-10 log probabilities of generated tokens when the generation length is less than 8 tokens. Also now keeps separate caches for each (model, dataset) combination, where it previously had a single cache for each model. Both of these help reduce the memory usage of the model output cache.
- Optimised cache saving/loading a bit, making the waiting time in between iterations slightly shorter.
- Removes the model output cache for a (model, dataset) combination when the benchmarking of the model on the dataset finishes successfully. Also removed indents in model output cache JSON files. Both of these help reducing the disk space used on caching.

### Fixed
- Only require generative models to output logprobs if the dataset is of a task that requires it. This caused the benchmarking to use excessive memory when benchmarking datasets that require long generative outputs, such as NER.

### Removed
- Removed some vLLM logging.

This closes #143 