### PR TITLE
fix: Add `generative` metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Now adds a `generative` key to the logged results, to enable parsing few-shot
+  evaluated models correctly when building leaderboards.
+
+
 ## [v9.1.0] - 2024-01-14
 ### Changed
 - Now only stores the top-10 log probabilities of generated tokens when the generation

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -292,6 +292,7 @@ class BenchmarkDataset(ABC):
             num_model_parameters=num_params,
             max_sequence_length=max_seq_length,
             vocabulary_size=vocab_size,
+            generative=benchmarking_generative_model,
             few_shot=benchmarking_generative_model,
             validation_split=self.benchmark_config.only_validation_split,
         )

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -50,12 +50,15 @@ class BenchmarkResult(BaseModel):
         # To be backwards compatible, we accept old results which changed the model
         # name with parameters rather than adding them as explicit parameters
         val_matches = re.search(r"\(.*val.*\)$", config["model"])
+        few_shot_matches = re.search(r"\(.*few-shot.*\)$", config["model"])
         config["model"] = re.sub(
             r"\(.*(few-shot|val).*\)$", "", config["model"]
         ).strip()
 
         # The default value for `few_shot` is True. It won't do anything if the model
         # is not generative, so this is fine
+        if "generative" not in config:
+            config["generative"] = few_shot_matches is not None
         if "few_shot" not in config:
             config["few_shot"] = True
 

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -32,6 +32,7 @@ class BenchmarkResult(BaseModel):
     num_model_parameters: int
     max_sequence_length: int
     vocabulary_size: int
+    generative: bool
     few_shot: bool
     validation_split: bool
 

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -56,6 +56,7 @@ class TestBenchmarkResult:
         """Test that the `BenchmarkResult` parameters are correct."""
         assert benchmark_result.dataset == "dataset"
         assert benchmark_result.model == "model"
+        assert benchmark_result.generative is False
         assert benchmark_result.few_shot is True
         assert benchmark_result.validation_split is False
         assert benchmark_result.num_model_parameters == 100
@@ -79,7 +80,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
-                    generative=True,
+                    generative=False,
                     few_shot=True,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -105,14 +106,13 @@ class TestBenchmarkResult:
                 dict(
                     dataset="dataset",
                     model="model (val)",
-                    generative=True,
                     few_shot=True,
                     **DATA_KWARGS,
                 ),
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
-                    generative=True,
+                    generative=False,
                     few_shot=True,
                     validation_split=True,
                     **DATA_KWARGS,
@@ -161,6 +161,7 @@ class TestBenchmarkResult:
                 num_model_parameters=benchmark_result.num_model_parameters,
                 max_sequence_length=benchmark_result.max_sequence_length,
                 vocabulary_size=benchmark_result.vocabulary_size,
+                generative=benchmark_result.generative,
                 few_shot=benchmark_result.few_shot,
                 validation_split=benchmark_result.validation_split,
             )

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -39,6 +39,7 @@ class TestBenchmarkResult:
         yield BenchmarkResult(
             dataset="dataset",
             model="model",
+            generative=False,
             few_shot=True,
             validation_split=False,
             **DATA_KWARGS,
@@ -78,6 +79,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
+                    generative=True,
                     few_shot=True,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -93,6 +95,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
+                    generative=True,
                     few_shot=True,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -102,12 +105,14 @@ class TestBenchmarkResult:
                 dict(
                     dataset="dataset",
                     model="model (val)",
+                    generative=True,
                     few_shot=True,
                     **DATA_KWARGS,
                 ),
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
+                    generative=True,
                     few_shot=True,
                     validation_split=True,
                     **DATA_KWARGS,
@@ -122,6 +127,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     dataset="dataset",
                     model="model",
+                    generative=True,
                     few_shot=True,
                     validation_split=True,
                     **DATA_KWARGS,
@@ -194,6 +200,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -210,6 +217,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="another-dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -226,6 +234,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -242,6 +251,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=True,
                     few_shot=True,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -258,6 +268,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -274,6 +285,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=True,
                     **DATA_KWARGS,
@@ -290,6 +302,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -297,6 +310,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
+                    generative=False,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,


### PR DESCRIPTION
This adds a `generative` key to the records stored to disk, which makes parsing the results for the leaderboards easier.

This is currently solely used to add a "(few-shot)" suffix to model IDs in the leaderboard, as we're planning to add finetuning support for decoders in the future.