### PR TITLE
Fix/few shot checking duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- When checking if a model has already been benchmarked, we only care about the
+  `few_shot` parameter if the model is generative.
+
+
 ## [v9.1.1] - 2024-01-15
 ### Fixed
 - Now adds a `generative` key to the logged results, to enable parsing few-shot

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -293,7 +293,8 @@ class BenchmarkDataset(ABC):
             max_sequence_length=max_seq_length,
             vocabulary_size=vocab_size,
             generative=benchmarking_generative_model,
-            few_shot=benchmarking_generative_model,
+            # TODO: This will be changed when we support finetuning of generative models
+            few_shot=True,
             validation_split=self.benchmark_config.only_validation_split,
         )
 

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -548,8 +548,8 @@ def model_has_been_benchmarked(
         if (
             record.model == model_id
             and record.dataset == dataset
-            and record.few_shot == few_shot
             and record.validation_split == validation_split
+            and (not record.generative or record.few_shot == few_shot)
         ):
             return True
     return False

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -235,7 +235,7 @@ class TestBenchmarkResult:
                 BenchmarkResult(
                     model="model",
                     dataset="dataset",
-                    generative=False,
+                    generative=True,
                     few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
@@ -254,6 +254,23 @@ class TestBenchmarkResult:
                     dataset="dataset",
                     generative=True,
                     few_shot=True,
+                    validation_split=False,
+                    **DATA_KWARGS,
+                )
+            ],
+            True,
+        ),
+        (
+            "model",
+            "dataset",
+            True,
+            False,
+            [
+                BenchmarkResult(
+                    model="model",
+                    dataset="dataset",
+                    generative=False,
+                    few_shot=False,
                     validation_split=False,
                     **DATA_KWARGS,
                 )
@@ -326,6 +343,7 @@ class TestBenchmarkResult:
         "model has not been benchmarked",
         "model few-shot has not been benchmarked",
         "model few-shot has been benchmarked",
+        "model few-shot has been benchmarked, but not generative",
         "model validation split has not been benchmarked",
         "model validation split has been benchmarked",
         "model has been benchmarked twice",


### PR DESCRIPTION
Previously we checked for the value of `few_shot` when checking if a model has already been benchmarked, no matter if the model is generative or not. Now we only check this if the model is generative.