### PR TITLE
chore: Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmarking_bug.md
+++ b/.github/ISSUE_TEMPLATE/benchmarking_bug.md
@@ -1,0 +1,19 @@
+---
+name: Benchmarking Bug Report
+about: Have you experienced a bug using the `scandeval` package?
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour.
+
+**Context (please complete the following information):**
+ - OS [e.g., MacOS, Ubuntu]:
+ - Python version [e.g., 3.10.6]:
+ - Package version [e.g., 0.1.2]:
+ - Output of `pip list` or `poetry show`:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Is the ScandEval benchmark missing a feature?
+title: "[FEATURE REQUEST] "
+labels: enhancement
+assignees: ''
+---
+
+**Describe the desired feature**
+Describe in reasonable detail what the feature should be doing.
+
+**Rationale**
+Explain why you think it is important to add this feature to ScandEval.

--- a/.github/ISSUE_TEMPLATE/missing_benchmarking_dataset.md
+++ b/.github/ISSUE_TEMPLATE/missing_benchmarking_dataset.md
@@ -1,0 +1,15 @@
+---
+name: Benchmark Dataset Request
+about: Do you think a particular benchmark dataset is missing in ScandEval?
+title: "[DATASET REQUEST] "
+labels: "benchmark dataset request"
+assignees: ''
+---
+
+**Describe the dataset**
+Include the name and a brief description of the dataset, along with a link to where it
+is currently hosted (doesn't have to be Hugging Face). Also include roughly how many
+samples the dataset contains, and what language it pertains to.
+
+**Rationale**
+Explain why you think it is important to include this dataset in ScandEval.

--- a/.github/ISSUE_TEMPLATE/missing_model_on_leaderboard.md
+++ b/.github/ISSUE_TEMPLATE/missing_model_on_leaderboard.md
@@ -1,0 +1,15 @@
+---
+name: Model Evaluation Request
+about: Would you like to have a particular model included in the leaderboards?
+title: "[MODEL EVALUATION REQUEST] "
+labels: "model evaluation request"
+assignees: ''
+---
+
+**Describe the dataset**
+Include the name and a brief description of the dataset, along with a link to where it
+is currently hosted (doesn't have to be Hugging Face). Also include roughly how many
+samples the dataset contains, and what language it pertains to.
+
+**Rationale**
+Explain why you think it is important to include this dataset in ScandEval.


### PR DESCRIPTION
This adds a few issue templates to ScandEval, to organise the incoming issues that have started to tick in.