### PR TITLE
chore: Only run MacOS CI if `macos` label is present

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
   pytest:
     strategy:
         matrix:
-            os: [ubuntu-latest]
+            os: [macos-latest, ubuntu-latest]
             python-version: ["3.10", "3.11"]
 
             # This runs the tests on MacOS only if the PR has the `macos` label
@@ -25,7 +25,6 @@ jobs:
             include:
               - shouldTestMacOs: true
                 os: macos-latest
-                python-version: "3.10"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ jobs:
             # This runs the tests on MacOS only if the PR has the `macos` label
             shouldTestMacOs:
               - ${{ contains(github.event.pull_request.labels.*.name, 'macos') }}
-            include:
-              - shouldTestMacOs: true
+            exclude:
+              - shouldTestMacOs: false
                 os: macos-latest
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
             os: [macos-latest, ubuntu-latest]
             python-version: ["3.10", "3.11"]
 
-            # This runs the tests on MacOS only if the PR has the `macos` label
+            # This runs the tests on MacOS if and only if the PR has the `macos` label
             shouldTestMacOs:
               - ${{ contains(github.event.pull_request.labels.*.name, 'macos') }}
             exclude:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,15 @@ jobs:
         matrix:
             os: [ubuntu-latest]
             python-version: ["3.10", "3.11"]
+
+            # This runs the tests on MacOS only if the PR has the `macos` label
+            shouldTestMacOs:
+              - ${{ contains(github.event.pull_request.labels.*.name, 'macos') }}
             include:
-              - os: macos-latest
+              - shouldTestMacOs: true
+                os: macos-latest
                 python-version: "3.10"
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
MacOS CI takes ~3x longer than the Ubuntu ones, so this only runs the MacOS ones if we manually add the `macos` label.