### PR TITLE
Feat/add scandeval version to benchmark result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added structured generation for the NER task, which enables the models to (almost)
   always output correct JSON, separating the NER capabilities from the JSON
   capabilities. JSON can be tested separately in a (future) coding benchmark.
+- Now adds `scandeval_version` to the output JSONL results, to make it easier to
+  determine when outdated results need re-benchmarking.
 
 ### Changed
 - Swapped primary/secondary metrics for the NER task, as the `MISC` tag varies too much

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -1,5 +1,6 @@
 """Class that benchmarks Scandinavian language models."""
 
+import importlib.metadata
 import json
 import logging
 import re
@@ -35,6 +36,7 @@ class BenchmarkResult(BaseModel):
     generative: bool
     few_shot: bool
     validation_split: bool
+    scandeval_version: str = importlib.metadata.version(__package__)
 
     @classmethod
     def from_dict(cls, config: dict) -> "BenchmarkResult":

--- a/tests/test_benchmarker.py
+++ b/tests/test_benchmarker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Generator, TypedDict
 
 import pytest
+from scandeval import __version__
 from scandeval.benchmarker import BenchmarkResult, model_has_been_benchmarked
 from scandeval.types import ScoreDict
 
@@ -65,6 +66,7 @@ class TestBenchmarkResult:
         assert benchmark_result.dataset_languages == ["da"]
         assert benchmark_result.task == "task"
         assert benchmark_result.results == dict()
+        assert benchmark_result.scandeval_version == __version__
 
     @pytest.mark.parametrize(
         argnames=["config", "expected"],
@@ -164,6 +166,7 @@ class TestBenchmarkResult:
                 generative=benchmark_result.generative,
                 few_shot=benchmark_result.few_shot,
                 validation_split=benchmark_result.validation_split,
+                scandeval_version=benchmark_result.scandeval_version,
             )
         )
         assert results_path.read_text() == f"\n{json_str}"


### PR DESCRIPTION
### Added
- Now adds `scandeval_version` to the output JSONL results, to make it easier to determine when outdated results need re-benchmarking.

This closes #168.