### PR TITLE
fix: Clear memory after benchmarking with vLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   rather than the previous `float32`. This does not affect generation performance.
 - Fixed formatting of summarization metrics.
 - Removed print output from `bert_score` during summarization metric computation.
+- Now clears GPU memory properly after finishing the benchmark of a generative model
+  with vLLM.
 
 
 ## [v9.1.2] - 2024-01-16

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -105,6 +105,13 @@ class VLLMModel:
                 _run_engine_with_fixed_progress_bars, self._model
             )
 
+    def __del__(self) -> None:
+        """Clear the GPU memory used by the model, and remove the model itself."""
+        destroy_model_parallel()
+        del self._model
+        clear_memory()
+        del self
+
     def generate(
         self,
         inputs: torch.Tensor,


### PR DESCRIPTION
### Fixed
- Now clears GPU memory properly after finishing the benchmark of a generative model with vLLM.

Closes #171 