### PR TITLE
Feat/add chat template to prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added structured generation for the NER task, which enables the models to (almost)
   always output correct JSON, separating the NER capabilities from the JSON
   capabilities. JSON can be tested separately in a (future) coding benchmark.
+- When benchmarking instruction tuned generative models, we now use the chat template
+  which has been set in the model's Hugging Face tokenizer config. If not set then we
+  won't use any chat template, and will instead separate examples with double newlines,
+  as with completion models.
 
 ### Changed
 - Swapped primary/secondary metrics for the NER task, as the `MISC` tag varies too much

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -459,6 +459,7 @@ class BenchmarkDataset(ABC):
                         few_shot_fn = partial(
                             self._apply_few_shot_prompt,
                             few_shot_examples=few_shot_examples,
+                            tokenizer=tokenizer,
                         )
                         test = test.map(
                             few_shot_fn, batched=True, load_from_cache_file=False

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -633,7 +633,7 @@ class BenchmarkDataset(ABC):
 
     @abstractmethod
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -642,6 +642,9 @@ class BenchmarkDataset(ABC):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to tokenise the examples. Used to apply the
+                chat template if the model we're benchmarking is instruction tuned.
 
         Returns:
             The examples with the few-shot prompt applied.

--- a/src/scandeval/named_entity_recognition.py
+++ b/src/scandeval/named_entity_recognition.py
@@ -521,7 +521,7 @@ class NamedEntityRecognition(BenchmarkDataset):
         return few_shot_examples
 
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -530,10 +530,12 @@ class NamedEntityRecognition(BenchmarkDataset):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to tokenise the examples. Used to apply the
+                chat template if the model we're benchmarking is instruction tuned.
 
         Returns:
-            dict:
-                The examples with the few-shot prompt applied.
+            The examples with the few-shot prompt applied.
         """
 
         def create_label(example: dict) -> str:
@@ -572,10 +574,19 @@ class NamedEntityRecognition(BenchmarkDataset):
             )
             for tokens in examples["tokens"]
         ]
-        examples["text"] = [
+        final_prompts = [
             few_shot_prompt + "\n\n" + new_prompt for new_prompt in new_prompts
         ]
 
+        if tokenizer.chat_template is not None:
+            final_prompts = [
+                tokenizer.apply_chat_template(
+                    conversation=[dict(role="user", content=prompt)],
+                )
+                for prompt in final_prompts
+            ]
+
+        examples["text"] = final_prompts
         return examples
 
     def _extract_labels_from_generation(

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -20,7 +20,7 @@ from transformers.modeling_utils import ModelOutput
 
 from .config import BenchmarkConfig, ModelConfig
 from .exceptions import InvalidBenchmark
-from .types import is_list_of_int, is_list_of_list_of_int, is_list_of_str
+from .types import Conversation, is_list_of_int, is_list_of_list_of_int, is_list_of_str
 
 logger = logging.getLogger(__package__)
 
@@ -42,6 +42,7 @@ class OpenAITokenizer:
     pad_token = "<pad>"
     padding_side = "left"
     is_fast = False
+    chat_template: str | None = None
 
     def __init__(
         self, model_config: ModelConfig, hf_model_config: PretrainedConfig
@@ -282,6 +283,18 @@ class OpenAITokenizer:
     def vocab_size(self) -> int:
         """Return the size of the vocabulary."""
         return self.encoding.max_token_value + 1
+
+    def apply_chat_template(self, conversation: Conversation) -> str:
+        """Apply a chat template to a conversation.
+
+        Args:
+            conversation:
+                The conversation to apply the chat template to.
+
+        Returns:
+            The conversation with the chat template applied.
+        """
+        raise NotImplementedError
 
 
 class OpenAIModel:

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -284,12 +284,14 @@ class OpenAITokenizer:
         """Return the size of the vocabulary."""
         return self.encoding.max_token_value + 1
 
-    def apply_chat_template(self, conversation: Conversation) -> str:
+    def apply_chat_template(self, conversation: Conversation, **kwargs) -> str:
         """Apply a chat template to a conversation.
 
         Args:
             conversation:
                 The conversation to apply the chat template to.
+            **kwargs:
+                Keyword arguments to pass to the tokenizer.
 
         Returns:
             The conversation with the chat template applied.

--- a/src/scandeval/protocols.py
+++ b/src/scandeval/protocols.py
@@ -155,12 +155,14 @@ class Tokenizer(Protocol):
         """
         ...
 
-    def apply_chat_template(self, conversation: Conversation) -> str:
+    def apply_chat_template(self, conversation: Conversation, **kwargs) -> str:
         """Apply a chat template to a conversation.
 
         Args:
             conversation:
                 The conversation to apply the chat template to.
+            **kwargs:
+                Keyword arguments to pass to the tokenizer.
 
         Returns:
             The conversation with the chat template applied.

--- a/src/scandeval/protocols.py
+++ b/src/scandeval/protocols.py
@@ -12,6 +12,7 @@ from transformers import (
 from transformers.utils import ModelOutput
 
 from .config import BenchmarkConfig, DatasetConfig, ModelConfig
+from .types import Conversation
 
 
 @runtime_checkable
@@ -31,6 +32,7 @@ class Tokenizer(Protocol):
     pad_token_id: int
     unk_token_id: int
     is_fast: bool
+    chat_template: str | None
 
     def __call__(self, text: str | list[str], **kwargs) -> BatchEncoding:
         """Call the tokenizer.
@@ -150,6 +152,18 @@ class Tokenizer(Protocol):
 
         Returns:
             The padded encoded inputs.
+        """
+        ...
+
+    def apply_chat_template(self, conversation: Conversation) -> str:
+        """Apply a chat template to a conversation.
+
+        Args:
+            conversation:
+                The conversation to apply the chat template to.
+
+        Returns:
+            The conversation with the chat template applied.
         """
         ...
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -257,6 +257,7 @@ class SequenceClassification(BenchmarkDataset):
         prompt_prefix = ""
         if self.dataset_config.prompt_prefix:
             prompt_prefix = self.dataset_config.prompt_prefix + "\n\n"
+        few_shot_prompt = prompt_prefix + "\n\n".join(few_shot_prompts)
 
         # Add the texts from the examples to the prompts. We remove newlines from the
         # examples as they have the special function to separate the few-shot examples
@@ -267,8 +268,6 @@ class SequenceClassification(BenchmarkDataset):
             ).strip()
             for text in examples["text"]
         ]
-
-        few_shot_prompt = prompt_prefix + "\n\n".join(few_shot_prompts)
         final_prompts = [
             few_shot_prompt + "\n\n" + new_prompt for new_prompt in new_prompts
         ]

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -273,11 +273,38 @@ class SequenceClassification(BenchmarkDataset):
         ]
 
         if tokenizer.chat_template is not None:
+            conversation = [
+                dict(role="user", content=prompt_prefix.strip()),
+                dict(role="assistant", content="Understood."),
+            ]
+            for few_shot_example in few_shot_examples:
+                conversation.extend(
+                    [
+                        dict(
+                            role="user",
+                            content=re.sub(
+                                r"\n+", "\n", few_shot_example["text"]
+                            ).strip(),
+                        ),
+                        dict(
+                            role="assistant",
+                            content=label_mapping[few_shot_example["label"].lower()],
+                        ),
+                    ]
+                )
             final_prompts = [
                 tokenizer.apply_chat_template(
-                    conversation=[dict(role="user", content=prompt)],
+                    conversation=conversation
+                    + [
+                        dict(
+                            role="user",
+                            content=re.sub(r"\n+", "\n", text).strip(),
+                        )
+                    ],
+                    tokenize=False,
+                    add_generation_prompt=True,
                 )
-                for prompt in final_prompts
+                for text in examples["text"]
             ]
 
         examples["text"] = final_prompts

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -159,7 +159,7 @@ class TextToText(BenchmarkDataset):
         return few_shot_examples
 
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -168,6 +168,9 @@ class TextToText(BenchmarkDataset):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to tokenise the examples. Used to apply the
+                chat template if the model we're benchmarking is instruction tuned.
 
         Returns:
             The examples with the few-shot prompt applied.
@@ -195,10 +198,19 @@ class TextToText(BenchmarkDataset):
             for text in examples["text"]
         ]
 
-        examples["text"] = [
+        final_prompts = [
             few_shot_prompt + "\n\n" + new_prompt for new_prompt in new_prompts
         ]
 
+        if tokenizer.chat_template is not None:
+            final_prompts = [
+                tokenizer.apply_chat_template(
+                    conversation=[dict(role="user", content=prompt)],
+                )
+                for prompt in final_prompts
+            ]
+
+        examples["text"] = final_prompts
         return examples
 
     def _extract_labels_from_generation(

--- a/src/scandeval/types.py
+++ b/src/scandeval/types.py
@@ -7,6 +7,7 @@ import numpy as np
 ScoreDict = dict[str, dict[str, float] | dict[str, list[dict[str, float]]]]
 Predictions = np.ndarray | list[str] | list[list[str]]
 Labels = np.ndarray | list[str] | list[list[str]]
+Conversation = list[dict[str, str]]
 
 
 def is_list_of_int(x: Any) -> TypeGuard[list[int]]:

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -17,7 +17,7 @@ from transformers.utils import ModelOutput
 
 from .config import DatasetConfig, ModelConfig
 from .dataset_tasks import NER
-from .utils import HiddenPrints, clear_memory, get_ner_parser
+from .utils import clear_memory, get_ner_parser
 
 logger = logging.getLogger(__package__)
 
@@ -76,7 +76,7 @@ class VLLMModel:
         self.dataset_config = dataset_config
         self.device = torch.device("cuda")
         self.tokenizer = tokenizer
-        with warnings.catch_warnings(), HiddenPrints():
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
 
             # This is required to be able to re-initialize the model, in case we


### PR DESCRIPTION
### Added
- When benchmarking instruction tuned generative models, we now use the chat template which has been set in the model's Hugging Face tokenizer config. If not set then we won't use any chat template, and will instead separate examples with double newlines, as with completion models.

This closes #167 