### PR TITLE
chore: Swap multiple choice metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Changed
+- Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC
+  as the primary metric and accuracy and secondary. This is due to the fact that MCC
+  handles class imbalance better.
+
+
 ## [v9.2.0] - 2024-01-24
 ### Added
 - Added (the English) datasets MMLU, ARC and HellaSwag, as well as Norwegian and

--- a/src/scandeval/dataset_tasks.py
+++ b/src/scandeval/dataset_tasks.py
@@ -137,16 +137,16 @@ KNOW = DatasetTask(
     supertask="sequence-classification",
     metrics=[
         MetricConfig(
-            name="accuracy",
-            pretty_name="Accuracy",
-            huggingface_id="accuracy",
-            results_key="accuracy",
-        ),
-        MetricConfig(
             name="mcc",
             pretty_name="Matthew's Correlation Coefficient",
             huggingface_id="matthews_correlation",
             results_key="matthews_correlation",
+        ),
+        MetricConfig(
+            name="accuracy",
+            pretty_name="Accuracy",
+            huggingface_id="accuracy",
+            results_key="accuracy",
         ),
     ],
     labels=["a", "b", "c", "d"],


### PR DESCRIPTION
### Changed
- Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC as the primary metric and accuracy and secondary. This is due to the fact that MCC handles class imbalance better.