### PR TITLE
Fix/prevent overflow and caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+- Prevents FP16 overflow by using -1e3 instead of -1e9 for ~0% probability logprobs
+  during generation with vLLM.
+- Avoids excessive disk usage by not caching processed datasets to disk, as we are
+  never using the cached versions anyway.
+
 ### Changed
 - Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC
   as the primary metric and accuracy and secondary. This is due to the fact that MCC

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -461,7 +461,10 @@ class BenchmarkDataset(ABC):
                             few_shot_examples=few_shot_examples,
                         )
                         test = test.map(
-                            few_shot_fn, batched=True, load_from_cache_file=False
+                            few_shot_fn,
+                            batched=True,
+                            load_from_cache_file=False,
+                            keep_in_memory=True,
                         )
 
                     prepared_test = self._preprocess_data(
@@ -478,6 +481,7 @@ class BenchmarkDataset(ABC):
                             ),
                             batched=True,
                             load_from_cache_file=False,
+                            keep_in_memory=True,
                         )
 
                     prepared_tests.append(prepared_test)

--- a/src/scandeval/named_entity_recognition.py
+++ b/src/scandeval/named_entity_recognition.py
@@ -421,7 +421,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                     self._apply_few_shot_prompt, few_shot_examples=few_shot_examples
                 )
                 dataset = dataset.map(
-                    few_shot_fn, batched=True, load_from_cache_file=False
+                    few_shot_fn,
+                    batched=True,
+                    load_from_cache_file=False,
+                    keep_in_memory=True,
                 )
 
             def tokenise(examples: dict) -> BatchEncoding:
@@ -432,7 +435,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                 )
 
             tokenised_dataset = dataset.map(
-                tokenise, batched=True, load_from_cache_file=False
+                tokenise,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         else:
@@ -442,7 +448,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                 label2id=kwargs["hf_model_config"].label2id,
             )
             tokenised_dataset = dataset.map(
-                map_fn, batched=True, load_from_cache_file=False
+                map_fn,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         return tokenised_dataset

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -85,6 +85,7 @@ class QuestionAnswering(BenchmarkDataset):
                 batch_size=10,
                 remove_columns=cols_to_remove,
                 load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         except NotImplementedError as e:

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -93,7 +93,10 @@ class SequenceClassification(BenchmarkDataset):
                 label2id=kwargs["hf_model_config"].label2id,
             )
             return tokenised.map(
-                numericalise, batched=True, load_from_cache_file=False
+                numericalise,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             ).remove_columns(["text"])
         else:
             return tokenised

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -52,7 +52,12 @@ class TextToText(BenchmarkDataset):
         def tokenise(examples: dict) -> BatchEncoding:
             return tokenizer(text=examples["text"], truncation=True, padding=False)
 
-        tokenised = dataset.map(tokenise, batched=True, load_from_cache_file=False)
+        tokenised = dataset.map(
+            tokenise,
+            batched=True,
+            load_from_cache_file=False,
+            keep_in_memory=True,
+        )
 
         return tokenised
 

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -223,7 +223,7 @@ class VLLMModel:
                     len(raw_output.outputs[0].logprobs) for raw_output in raw_outputs
                 )
                 scores = [
-                    torch.full(size=(batch_size, vocab_size), fill_value=-1e9)
+                    torch.full(size=(batch_size, vocab_size), fill_value=-1e3)
                     for _ in range(max_seq_len)
                 ]
 
@@ -298,7 +298,7 @@ class VLLMModel:
             def no_tabs_or_newlines(_: list[int], scores: torch.Tensor) -> torch.Tensor:
                 mask = torch.zeros_like(scores)
                 for forbidden_token_id in forbidden_token_ids:
-                    mask[forbidden_token_id] = -1e9
+                    mask[forbidden_token_id] = -1e3
                 return scores + mask
 
             logits_processors.append(no_tabs_or_newlines)


### PR DESCRIPTION
### Fixed
- Prevents FP16 overflow by using -1e3 instead of -1e9 for ~0% probability logprobs during generation with vLLM.
- Avoids excessive disk usage by not caching processed datasets to disk, as we are never using the cached versions anyway.

Closes #193 and enables #177 and #178.