### PR TITLE
Fix/stripping of prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ coverage.xml
 *.mo
 *.pot
 
-# Django stuff:
+# Log files
 *.log
 
 # Sphinx documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   during generation with vLLM.
 - Avoids excessive disk usage by not caching processed datasets to disk, as we are
   never using the cached versions anyway.
+- In sequence classification tasks, we now only strip the prompts if the model's
+  tokenizer includes a prefix space when tokenizing the labels.
 
 ### Changed
 - Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC
   as the primary metric and accuracy and secondary. This is due to the fact that MCC
   handles class imbalance better.
+- Number of generated tokens for sequence classification tasks has been changed back to
+  3 (from 1). This makes no difference to open source models, as we only use the
+  logprobs from the first token anyway, but it *does* make a difference to closed
+  source models where the logprobs are not available (like OpenAI's chat models), as
+  we're instead calculating word edit distance to the labels.
 
 
 ## [v9.2.0] - 2024-01-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   during generation with vLLM.
 - Avoids excessive disk usage by not caching processed datasets to disk, as we are
   never using the cached versions anyway.
-- In sequence classification tasks, we now only strip the prompts if the model's
-  tokenizer includes a prefix space when tokenizing the labels.
+- We now only strip the prompts if the model's tokenizer includes a prefix space when
+  tokenizing the labels.
 - Fixed an issue with OOM errors when changing from benchmarking one generative model
   to another.
 - When testing a model's maximum sequence length, we put dummy inputs into them. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+- Prevents FP16 overflow by using -1e3 instead of -1e9 for ~0% probability logprobs
+  during generation with vLLM.
+- Avoids excessive disk usage by not caching processed datasets to disk, as we are
+  never using the cached versions anyway.
+
 ### Changed
 - Swapped primary/secondary metrics for the multiple choice tasks, where we now set MCC
   as the primary metric and accuracy and secondary. This is due to the fact that MCC

--- a/makefile
+++ b/makefile
@@ -102,7 +102,10 @@ view-docs:  ## View documentation
 		"$${openCmd}" docs/{{ cookiecutter.project_name }}.html
 
 test:  ## Run tests
-	@poetry run pytest && poetry run readme-cov && rm .coverage*
+	@USE_CUDA=1 poetry run pytest \
+		&& poetry run pytest \
+		&& poetry run readme-cov \
+		&& rm .coverage*
 
 tree:  ## Print directory tree
 	@tree -a --gitignore -I .git .

--- a/makefile
+++ b/makefile
@@ -102,7 +102,11 @@ view-docs:  ## View documentation
 		"$${openCmd}" docs/{{ cookiecutter.project_name }}.html
 
 test:  ## Run tests
-	@USE_CUDA=1 poetry run pytest \
+	@echo "Running tests with CUDA and vLLM:" \
+		&& USE_CUDA=1 USE_VLLM=1 poetry run pytest \
+		&& echo "Running tests with CUDA and no vLLM:" \
+		&& USE_CUDA=1 USE_VLLM=0 poetry run pytest \
+		&& echo "Running tests with CPU:" \
 		&& poetry run pytest \
 		&& poetry run readme-cov \
 		&& rm .coverage*

--- a/makefile
+++ b/makefile
@@ -102,14 +102,16 @@ view-docs:  ## View documentation
 		"$${openCmd}" docs/{{ cookiecutter.project_name }}.html
 
 test:  ## Run tests
-	@echo "Running tests with CUDA and vLLM:" \
-		&& USE_CUDA=1 USE_VLLM=1 poetry run pytest \
-		&& echo "Running tests with CUDA and no vLLM:" \
-		&& USE_CUDA=1 USE_VLLM=0 poetry run pytest \
-		&& echo "Running tests with CPU:" \
-		&& poetry run pytest \
+	@date "+%H:%M:%S ⋅ Running tests with CUDA and vLLM..." \
+		&& USE_CUDA=1 USE_VLLM=1 poetry run pytest -q > tests_with_cuda_and_vllm.log; \
+		date "+%H:%M:%S ⋅ Running tests with CUDA and no vLLM..." \
+		&& USE_CUDA=1 USE_VLLM=0 poetry run pytest -q > tests_with_cuda_and_no_vllm.log; \
+		date "+%H:%M:%S ⋅ Running tests with CPU..." \
+		&& USE_CUDA=0 poetry run pytest -q > tests_with_cpu.log; \
+		date "+%H:%M:%S ⋅ Updating coverage badge..." \
 		&& poetry run readme-cov \
-		&& rm .coverage*
+		&& rm .coverage* \
+		&& date "+%H:%M:%S ⋅ Done!"
 
 tree:  ## Print directory tree
 	@tree -a --gitignore -I .git .

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -461,7 +461,10 @@ class BenchmarkDataset(ABC):
                             few_shot_examples=few_shot_examples,
                         )
                         test = test.map(
-                            few_shot_fn, batched=True, load_from_cache_file=False
+                            few_shot_fn,
+                            batched=True,
+                            load_from_cache_file=False,
+                            keep_in_memory=True,
                         )
 
                     prepared_test = self._preprocess_data(
@@ -478,6 +481,7 @@ class BenchmarkDataset(ABC):
                             ),
                             batched=True,
                             load_from_cache_file=False,
+                            keep_in_memory=True,
                         )
 
                     prepared_tests.append(prepared_test)

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -83,6 +83,15 @@ class BenchmarkDataset(ABC):
             for metric_cfg in dataset_config.task.metrics
         }
 
+        # Set logging level based on verbosity
+        if hasattr(sys, "_called_from_test"):
+            logging_level = logging.CRITICAL
+        elif self.benchmark_config.verbose:
+            logging_level = logging.DEBUG
+        else:
+            logging_level = logging.INFO
+        logger.setLevel(logging_level)
+
     def benchmark(self, model_id: str) -> tuple[ScoreDict, dict[str, bool | int]]:
         """Benchmark a model.
 
@@ -422,7 +431,7 @@ class BenchmarkDataset(ABC):
 
         # Prepare the train and validation datasets
         with tqdm(
-            total=12,
+            total=4 if hasattr(sys, "_called_from_test") else 12,
             desc="Preprocessing data splits",
             disable=hasattr(sys, "_called_from_test"),
         ) as pbar:

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -421,7 +421,11 @@ class BenchmarkDataset(ABC):
         )
 
         # Prepare the train and validation datasets
-        with tqdm(total=12, desc="Preprocessing data splits") as pbar:
+        with tqdm(
+            total=12,
+            desc="Preprocessing data splits",
+            disable=hasattr(sys, "_called_from_test"),
+        ) as pbar:
             # When evaluating generative models we only need the test split, so
             # there's no need to prepare the train split
             try:

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -459,6 +459,7 @@ class BenchmarkDataset(ABC):
                         few_shot_fn = partial(
                             self._apply_few_shot_prompt,
                             few_shot_examples=few_shot_examples,
+                            tokenizer=tokenizer,
                         )
                         test = test.map(
                             few_shot_fn,
@@ -637,7 +638,7 @@ class BenchmarkDataset(ABC):
 
     @abstractmethod
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -646,6 +647,8 @@ class BenchmarkDataset(ABC):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to encode the few-shot prompt.
 
         Returns:
             The examples with the few-shot prompt applied.

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -83,10 +83,6 @@ class BenchmarkDataset(ABC):
             for metric_cfg in dataset_config.task.metrics
         }
 
-        # Set logging level based on verbosity
-        logging_level = logging.DEBUG if self.benchmark_config.verbose else logging.INFO
-        logger.setLevel(logging_level)
-
     def benchmark(self, model_id: str) -> tuple[ScoreDict, dict[str, bool | int]]:
         """Benchmark a model.
 

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import json
 import logging
 import re
+import sys
 from pathlib import Path
 from shutil import rmtree
 from time import sleep
@@ -240,7 +241,12 @@ class Benchmarker:
             self.benchmark_results = list()
 
         # Set logging level based on verbosity
-        logging_level = logging.DEBUG if verbose else logging.INFO
+        if hasattr(sys, "_called_from_test"):
+            logging_level = logging.CRITICAL
+        elif self.benchmark_config.verbose:
+            logging_level = logging.DEBUG
+        else:
+            logging_level = logging.INFO
         logger.setLevel(logging_level)
 
         # Initialise a dataset factory

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -56,7 +56,7 @@ SWEREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ANGRY_TWEETS_CONFIG = DatasetConfig(
@@ -72,7 +72,7 @@ ANGRY_TWEETS_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 NOREC_CONFIG = DatasetConfig(
@@ -88,7 +88,7 @@ NOREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="nøytral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 # ISREC_CONFIG = DatasetConfig(
@@ -104,7 +104,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="jákvætt", neutral="hlutlaust", negative="neikvætt"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=1,
+#     max_generated_tokens=3,
 # )
 
 # FOREC_CONFIG = DatasetConfig(
@@ -120,7 +120,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="positivur", neutral="neutralur", negative="negativur"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=1,
+#     max_generated_tokens=3,
 # )
 
 SB10K_CONFIG = DatasetConfig(
@@ -136,7 +136,7 @@ SB10K_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 DUTCH_SOCIAL_CONFIG = DatasetConfig(
@@ -152,7 +152,7 @@ DUTCH_SOCIAL_CONFIG = DatasetConfig(
         positive="positief", neutral="neutraal", negative="negatief"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SST5_CONFIG = DatasetConfig(
@@ -168,7 +168,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 # TODO: Icelandic Sentiment Classification
@@ -397,7 +397,7 @@ SCALA_SV_CONFIG = DatasetConfig(
     prompt_template="Mening: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_DA_CONFIG = DatasetConfig(
@@ -410,7 +410,7 @@ SCALA_DA_CONFIG = DatasetConfig(
     prompt_template="Sætning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_NB_CONFIG = DatasetConfig(
@@ -423,7 +423,7 @@ SCALA_NB_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_NN_CONFIG = DatasetConfig(
@@ -436,7 +436,7 @@ SCALA_NN_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_IS_CONFIG = DatasetConfig(
@@ -449,7 +449,7 @@ SCALA_IS_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nMálfræðilega rétt: {label}",
     prompt_label_mapping=dict(correct="já", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 
@@ -463,7 +463,7 @@ SCALA_FO_CONFIG = DatasetConfig(
     prompt_template="Setningur: {text}\nMállæruliga rættur: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_DE_CONFIG = DatasetConfig(
@@ -476,7 +476,7 @@ SCALA_DE_CONFIG = DatasetConfig(
     prompt_template="Satz: {text}\nGrammatikalisch richtig: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nein"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_NL_CONFIG = DatasetConfig(
@@ -489,7 +489,7 @@ SCALA_NL_CONFIG = DatasetConfig(
     prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nee"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 SCALA_EN_CONFIG = DatasetConfig(
@@ -503,7 +503,7 @@ SCALA_EN_CONFIG = DatasetConfig(
     prompt_template="Sentence: {text}\nGrammatically correct: {label}",
     prompt_label_mapping=dict(correct="yes", incorrect="no"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 
@@ -716,7 +716,7 @@ MMLU_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_NO_CONFIG = DatasetConfig(
@@ -729,7 +729,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_SV_CONFIG = DatasetConfig(
@@ -742,7 +742,7 @@ MMLU_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_IS_CONFIG = DatasetConfig(
@@ -755,7 +755,7 @@ MMLU_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_DE_CONFIG = DatasetConfig(
@@ -768,7 +768,7 @@ MMLU_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_NL_CONFIG = DatasetConfig(
@@ -781,7 +781,7 @@ MMLU_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 MMLU_CONFIG = DatasetConfig(
@@ -794,7 +794,7 @@ MMLU_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_DA_CONFIG = DatasetConfig(
@@ -807,7 +807,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_NO_CONFIG = DatasetConfig(
@@ -820,7 +820,7 @@ ARC_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_SV_CONFIG = DatasetConfig(
@@ -833,7 +833,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_IS_CONFIG = DatasetConfig(
@@ -846,7 +846,7 @@ ARC_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_DE_CONFIG = DatasetConfig(
@@ -859,7 +859,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_NL_CONFIG = DatasetConfig(
@@ -872,7 +872,7 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 ARC_CONFIG = DatasetConfig(
@@ -885,7 +885,7 @@ ARC_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=20,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 # TODO: Faroese knowledge
@@ -903,7 +903,7 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_NO_CONFIG = DatasetConfig(
@@ -916,7 +916,7 @@ HELLASWAG_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_SV_CONFIG = DatasetConfig(
@@ -929,7 +929,7 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_IS_CONFIG = DatasetConfig(
@@ -942,7 +942,7 @@ HELLASWAG_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
@@ -955,7 +955,7 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_NL_CONFIG = DatasetConfig(
@@ -968,7 +968,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 HELLASWAG_CONFIG = DatasetConfig(
@@ -981,7 +981,7 @@ HELLASWAG_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 # TODO: Faroese common sense reasoning

--- a/src/scandeval/finetuning.py
+++ b/src/scandeval/finetuning.py
@@ -417,7 +417,7 @@ def get_training_args(
             logging_steps=30,
             save_steps=30,
             max_steps=2 if hasattr(sys, "_called_from_test") else 10_000,
-            use_cpu=hasattr(sys, "_called_from_test"),
+            use_cpu=benchmark_config.device == torch.device("cpu"),
             report_to=[],
             save_total_limit=1,
             per_device_train_batch_size=batch_size,

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -261,7 +261,11 @@ def generate_single_iteration(
         itr = (
             dataloader
             if isinstance(model, VLLMModel)
-            else tqdm(dataloader, leave=False)
+            else tqdm(
+                iterable=dataloader,
+                leave=False,
+                disable=hasattr(sys, "_called_from_test"),
+            )
         )
 
         # Generate the completions for the non-cached examples

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -151,7 +152,12 @@ class ModelCache:
 
         # Store the generated sequences in the cache, one by one
         # TODO: This is a bit slow, should be optimized
-        with tqdm(model_input, desc="Caching model outputs", leave=False) as pbar:
+        with tqdm(
+            iterable=model_input,
+            desc="Caching model outputs",
+            leave=False,
+            disable=hasattr(sys, "_called_from_test"),
+        ) as pbar:
             for sample_idx, sample in enumerate(pbar):
                 decoded_inputs = tokenizer.decode(
                     token_ids=sample, skip_special_tokens=True

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -1,6 +1,7 @@
 """Model setup for Hugging Face Hub models."""
 
 import logging
+import os
 import warnings
 from json import JSONDecodeError
 from time import sleep
@@ -253,6 +254,7 @@ class HFModelSetup:
         use_vllm = (
             model_config.task in GENERATIVE_MODEL_TASKS
             and self.benchmark_config.device == torch.device("cuda")
+            and os.getenv("USE_VLLM", True)
         )
 
         if use_vllm:

--- a/src/scandeval/named_entity_recognition.py
+++ b/src/scandeval/named_entity_recognition.py
@@ -421,7 +421,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                     self._apply_few_shot_prompt, few_shot_examples=few_shot_examples
                 )
                 dataset = dataset.map(
-                    few_shot_fn, batched=True, load_from_cache_file=False
+                    few_shot_fn,
+                    batched=True,
+                    load_from_cache_file=False,
+                    keep_in_memory=True,
                 )
 
             def tokenise(examples: dict) -> BatchEncoding:
@@ -432,7 +435,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                 )
 
             tokenised_dataset = dataset.map(
-                tokenise, batched=True, load_from_cache_file=False
+                tokenise,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         else:
@@ -442,7 +448,10 @@ class NamedEntityRecognition(BenchmarkDataset):
                 label2id=kwargs["hf_model_config"].label2id,
             )
             tokenised_dataset = dataset.map(
-                map_fn, batched=True, load_from_cache_file=False
+                map_fn,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         return tokenised_dataset

--- a/src/scandeval/named_entity_recognition.py
+++ b/src/scandeval/named_entity_recognition.py
@@ -530,7 +530,7 @@ class NamedEntityRecognition(BenchmarkDataset):
         return few_shot_examples
 
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -539,10 +539,11 @@ class NamedEntityRecognition(BenchmarkDataset):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to encode the few-shot prompt.
 
         Returns:
-            dict:
-                The examples with the few-shot prompt applied.
+            The examples with the few-shot prompt applied.
         """
 
         def create_label(example: dict) -> str:

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -85,6 +85,7 @@ class QuestionAnswering(BenchmarkDataset):
                 batch_size=10,
                 remove_columns=cols_to_remove,
                 load_from_cache_file=False,
+                keep_in_memory=True,
             )
 
         except NotImplementedError as e:

--- a/src/scandeval/question_answering.py
+++ b/src/scandeval/question_answering.py
@@ -229,7 +229,7 @@ class QuestionAnswering(BenchmarkDataset):
         return few_shot_examples
 
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -238,6 +238,8 @@ class QuestionAnswering(BenchmarkDataset):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to encode the few-shot prompt.
 
         Returns:
             The examples with the few-shot prompt applied.

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -93,7 +93,10 @@ class SequenceClassification(BenchmarkDataset):
                 label2id=kwargs["hf_model_config"].label2id,
             )
             return tokenised.map(
-                numericalise, batched=True, load_from_cache_file=False
+                numericalise,
+                batched=True,
+                load_from_cache_file=False,
+                keep_in_memory=True,
             ).remove_columns(["text"])
         else:
             return tokenised

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -52,7 +52,12 @@ class TextToText(BenchmarkDataset):
         def tokenise(examples: dict) -> BatchEncoding:
             return tokenizer(text=examples["text"], truncation=True, padding=False)
 
-        tokenised = dataset.map(tokenise, batched=True, load_from_cache_file=False)
+        tokenised = dataset.map(
+            tokenise,
+            batched=True,
+            load_from_cache_file=False,
+            keep_in_memory=True,
+        )
 
         return tokenised
 

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -164,7 +164,7 @@ class TextToText(BenchmarkDataset):
         return few_shot_examples
 
     def _apply_few_shot_prompt(
-        self, examples: dict, few_shot_examples: list[dict]
+        self, examples: dict, few_shot_examples: list[dict], tokenizer: Tokenizer
     ) -> dict:
         """Apply a few-shot prompt to the examples.
 
@@ -173,6 +173,8 @@ class TextToText(BenchmarkDataset):
                 The examples to apply the prompt to.
             few_shot_examples:
                 The examples to be included in the few-shot prompt.
+            tokenizer:
+                The tokenizer to use to encode the few-shot prompt.
 
         Returns:
             The examples with the few-shot prompt applied.

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -1,6 +1,7 @@
 """A wrapper for vLLM models."""
 
 import logging
+import sys
 import warnings
 from pathlib import Path
 from types import MethodType
@@ -331,7 +332,11 @@ class VLLMModel:
 def _run_engine_with_fixed_progress_bars(self, use_tqdm: bool) -> list[RequestOutput]:
     if use_tqdm:
         num_requests = self.llm_engine.get_num_unfinished_requests()
-        pbar = tqdm(total=num_requests, leave=False)
+        pbar = tqdm(
+            total=num_requests,
+            leave=False,
+            disable=hasattr(sys, "_called_from_test"),
+        )
 
     # Run the engine.
     outputs: list[RequestOutput] = list()

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -223,7 +223,7 @@ class VLLMModel:
                     len(raw_output.outputs[0].logprobs) for raw_output in raw_outputs
                 )
                 scores = [
-                    torch.full(size=(batch_size, vocab_size), fill_value=-1e9)
+                    torch.full(size=(batch_size, vocab_size), fill_value=-1e3)
                     for _ in range(max_seq_len)
                 ]
 
@@ -298,7 +298,7 @@ class VLLMModel:
             def no_tabs_or_newlines(_: list[int], scores: torch.Tensor) -> torch.Tensor:
                 mask = torch.zeros_like(scores)
                 for forbidden_token_id in forbidden_token_ids:
-                    mask[forbidden_token_id] = -1e9
+                    mask[forbidden_token_id] = -1e3
                 return scores + mask
 
             logits_processors.append(no_tabs_or_newlines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,11 +43,17 @@ def auth() -> Generator[str | bool, None, None]:
 
 
 @pytest.fixture(scope="session")
+def device() -> Generator[torch.device, None, None]:
+    """Yields the device to use for the tests."""
+    device = torch.device("cuda" if os.environ["USE_CUDA"] else "cpu")
+    yield device
+
+
+@pytest.fixture(scope="session")
 def benchmark_config(
-    language, dataset_task, auth
+    language, dataset_task, auth, device
 ) -> Generator[BenchmarkConfig, None, None]:
     """Yields a benchmark configuration used in tests."""
-    device = torch.device("cuda" if os.environ["USE_CUDA"] else "cpu")
     yield BenchmarkConfig(
         model_languages=[language],
         dataset_languages=[language],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def benchmark_config(
     language, dataset_task, auth
 ) -> Generator[BenchmarkConfig, None, None]:
     """Yields a benchmark configuration used in tests."""
+    device = torch.device("cuda" if os.environ["USE_CUDA"] else "cpu")
     yield BenchmarkConfig(
         model_languages=[language],
         dataset_languages=[language],
@@ -60,7 +61,7 @@ def benchmark_config(
         openai_api_key=None,
         progress_bar=False,
         save_results=True,
-        device=torch.device("cpu"),
+        device=device,
         verbose=False,
         trust_remote_code=True,
         load_in_4bit=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def auth() -> Generator[str | bool, None, None]:
 @pytest.fixture(scope="session")
 def device() -> Generator[torch.device, None, None]:
     """Yields the device to use for the tests."""
-    device = torch.device("cuda" if os.environ["USE_CUDA"] else "cpu")
+    device = torch.device("cuda" if os.getenv("USE_CUDA", False) else "cpu")
     yield device
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 """Unit tests for the `config` module."""
 
 import pytest
-import torch
 from scandeval.config import (
     BenchmarkConfig,
     DatasetConfig,
@@ -83,7 +82,7 @@ class TestBenchmarkConfig:
         assert isinstance(benchmark_config, BenchmarkConfig)
 
     def test_attributes_correspond_to_arguments(
-        self, benchmark_config, language, dataset_task, auth
+        self, benchmark_config, language, dataset_task, auth, device
     ):
         """Test that the benchmark config attributes correspond to the arguments."""
         assert benchmark_config.model_languages == [language]
@@ -98,7 +97,7 @@ class TestBenchmarkConfig:
         assert benchmark_config.openai_api_key is None
         assert benchmark_config.progress_bar is False
         assert benchmark_config.save_results is True
-        assert benchmark_config.device == torch.device("cpu")
+        assert benchmark_config.device == device
         assert benchmark_config.verbose is False
         assert benchmark_config.trust_remote_code is True
         assert benchmark_config.load_in_4bit is None

--- a/tests/test_model_setups/test_hf.py
+++ b/tests/test_model_setups/test_hf.py
@@ -8,7 +8,7 @@ from scandeval.model_setups.hf import HFModelSetup
 
 
 @pytest.mark.parametrize(
-    argnames=["device", "model_id", "expected"],
+    argnames=["test_device", "model_id", "expected"],
     argvalues=[
         ("cuda", "microsoft/mdeberta-v3-base", None),
         ("cuda", "jonfd/electra-small-nordic", None),
@@ -38,9 +38,12 @@ from scandeval.model_setups.hf import HFModelSetup
         "cpu: phi-2",
     ],
 )
-def test_torch_dtype_is_set_correctly(benchmark_config, device, model_id, expected):
+def test_torch_dtype_is_set_correctly(
+    benchmark_config, test_device, model_id, expected
+):
+    """Test that the torch dtype is set correctly."""
     benchmark_config_copy = copy.deepcopy(benchmark_config)
-    benchmark_config_copy.device = torch.device(device)
+    benchmark_config_copy.device = torch.device(test_device)
     model_setup = HFModelSetup(benchmark_config=benchmark_config_copy)
     hf_model_config = model_setup._load_hf_model_config(
         model_id=model_id,


### PR DESCRIPTION
## Summary
Main thing in this PR is dealing with when we're stripping the prompts. A prompt can look like the following:

`Tweet: <some tweet>\nSentiment:`

Note that there's no space after the last colon. When we're asking the model for the next token then it might output the token ` positive` (note the prefix space), which is great, but it might also simply output a whitespace token ` `, with `positive` following that. This is an issue when we're looking at the probability distribution of the next token, since we want the distribution of the next "meaningful" token.

To counter this, we tokenise `positive` and ` positive` separately, and check if the tokens of `positive` are included in the tokens of ` positive`. If this is the case, then we _should not_ strip the prompts, since the initial whitespace would be recorded as a separate token if we strip.

As an example of this, the tokens of `positive` could, e.g., be [`pos`, `itive`], and the tokens of ` positive` could be [` `, `pos`, `itive`]. In this case we _do not_ want to strip the prompt, since we would just get the whitespace ` ` token as the first generated token in that case. As another example, the tokens of `positive` could be [`po`, `sitive`] and the tokens of ` positive` be [` positive`], in which case we _do_ want to strip the prompt, since we care about the probability of ` positive`.

## Changelog Additions
### Changed
- Number of generated tokens for sequence classification tasks has been changed back to 3 (from 1). This makes no difference to open source models, as we only use the logprobs from the first token anyway, but it *does* make a difference to closed source models where the logprobs are not available (like OpenAI's chat models), as we're instead calculating word edit distance to the labels.

### Fixed
- We now only strip the prompts if the model's tokenizer includes a prefix space when tokenizing the labels.


This closes #194.