### PR TITLE
Feat/add informative error when benchmarking encoders on generative tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Now throws a more informative error when attempting to benchmark a non-generative
+  model on a generative task.
+
 ### Changed
 - Many dependencies are now optional, to make the package less bloated. These extras
   are `jax`, for models based on the JAX framework, `generative` for evaluating

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -34,6 +34,8 @@ from ..exceptions import (
 from ..languages import get_all_languages
 from ..protocols import GenerativeModel, Tokenizer
 from ..utils import (
+    GENERATIVE_DATASET_SUPERTASKS,
+    GENERATIVE_DATASET_TASKS,
     GENERATIVE_MODEL_TASKS,
     block_terminal_output,
     create_model_cache_dir,
@@ -317,6 +319,14 @@ class HFModelSetup:
                         model_cls_supertask = "causal-l-m"
                     elif model_config.task == "text2text-generation":
                         model_cls_supertask = "seq-2-seq-l-m"
+                    elif (
+                        dataset_config.task.name in GENERATIVE_DATASET_TASKS
+                        or supertask in GENERATIVE_DATASET_SUPERTASKS
+                    ):
+                        raise InvalidBenchmark(
+                            f"The {dataset_config.task.name!r} task is not supported "
+                            f"for the model {model_id!r}."
+                        )
                     else:
                         model_cls_supertask = supertask
                     model_cls_or_none: Type[PreTrainedModel] | None = get_class_by_name(


### PR DESCRIPTION
### Added
- Now throws a more informative error when attempting to benchmark a non-generative model on a generative task.

This closes #141 