### PR TITLE
Fix/error in extracting predicted label ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `vllm.LLM` initialisation, causing some models not being loaded in vLLM.
 - An error occured if a tokenizer had no defined BOS token, which happens for some
   generative models. It is now set to be equal to the EOS token in that case.
+- Fixed error related to the extraction of predicted labels in sequence classification
+  tasks for generative models, which unfairly evaluated generative models that require
+  a prefix space on the labels (which are most of them currently).
 
 ### Removed
 - Removed the `-d` shorthand for `--dataset` in the CLI, to encourage the use of `-t`

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -367,7 +367,7 @@ def get_closest_logprobs_labels(
         if add_prefix_space_to_labels:
             label_ready_for_tokenization = " " + label_ready_for_tokenization
         candidate_label_ids: list[list[int]] = tokenizer(
-            [candidate_label.lower()], add_special_tokens=False
+            [label_ready_for_tokenization.lower()], add_special_tokens=False
         )["input_ids"]
         candidate_label_id: int = candidate_label_ids[0][0]
         pred_logprobs[:, idx] = generation_logprobs[:, 0, candidate_label_id]


### PR DESCRIPTION
### Fixed
- Fixed error related to the extraction of predicted labels in sequence classification tasks for generative models, which unfairly evaluated generative models that require a prefix space on the labels (which are most of them currently).