### PR TITLE
fix: Check if any extras are needed to check model existence, and inform user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- There was an error caused if an old version of the `openai` package was installed and
+  if the `scandeval` package was checking if a model exists as an OpenAI model. Now an
+  informative error is thrown if the model is not found on any available platforms, as
+  well as noting the extras that are missing, which prevents the package from checking
+  existence on those platforms.
+
+
 ## [v10.0.1] - 2024-02-12
 ### Fixed
 - A prefix space was added to labels in sequence classification tasks that

--- a/src/scandeval/model_setups/fresh.py
+++ b/src/scandeval/model_setups/fresh.py
@@ -49,7 +49,7 @@ class FreshModelSetup:
     def _strip_model_id(model_id: str) -> str:
         return re.sub("(@.*$|^fresh-)", "", model_id)
 
-    def model_exists(self, model_id: str) -> bool:
+    def model_exists(self, model_id: str) -> bool | str:
         """Check if a model ID denotes a fresh model.
 
         Args:
@@ -57,7 +57,8 @@ class FreshModelSetup:
                 The model ID.
 
         Returns:
-            Whether the model exists as a fresh model.
+            Whether the model exists as a fresh model, or the name of an extra that
+            needs to be installed to check if the model exists.
         """
         return self._strip_model_id(model_id=model_id) in FRESH_MODELS
 

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -70,15 +70,16 @@ class HFModelSetup:
         """
         self.benchmark_config = benchmark_config
 
-    def model_exists(self, model_id: str) -> bool:
-        """Check if a model ID denotes an OpenAI model.
+    def model_exists(self, model_id: str) -> bool | str:
+        """Check if a model ID denotes a model on the Hugging Face Hub.
 
         Args:
             model_id:
                 The model ID.
 
         Returns:
-            Whether the model exists on OpenAI.
+            Whether the model exists on the Hugging Face Hub, or the name of an extra
+            that needs to be installed to check if the model exists.
         """
         # Extract the revision from the model_id, if present
         model_id, revision = (

--- a/src/scandeval/model_setups/local.py
+++ b/src/scandeval/model_setups/local.py
@@ -32,7 +32,7 @@ class LocalModelSetup:
         """
         self.benchmark_config = benchmark_config
 
-    def model_exists(self, model_id: str) -> bool:
+    def model_exists(self, model_id: str) -> bool | str:
         """Check if a model exists locally.
 
         Args:
@@ -40,7 +40,8 @@ class LocalModelSetup:
                 The model ID.
 
         Returns:
-            Whether the model exists locally.
+            Whether the model exists locally, or the name of an extra that needs to be
+            installed to check if the model exists.
         """
         # Ensure that `model_id` is a Path object
         model_dir = Path(model_id)

--- a/src/scandeval/model_setups/openai.py
+++ b/src/scandeval/model_setups/openai.py
@@ -7,7 +7,6 @@ from transformers import PretrainedConfig, PreTrainedModel
 
 from ..config import BenchmarkConfig, DatasetConfig, ModelConfig
 from ..enums import Framework, ModelType
-from ..exceptions import NeedsExtraInstalled
 from ..openai_models import OpenAIModel, OpenAITokenizer
 from ..protocols import GenerativeModel, Tokenizer
 from ..utils import create_model_cache_dir
@@ -16,8 +15,9 @@ logger = logging.getLogger(__package__)
 
 try:
     import openai
+    import openai.models
     import tiktoken
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     openai = None
     tiktoken = None
 
@@ -70,7 +70,7 @@ class OpenAIModelSetup:
         """
         self.benchmark_config = benchmark_config
 
-    def model_exists(self, model_id: str) -> bool:
+    def model_exists(self, model_id: str) -> bool | str:
         """Check if a model ID denotes an OpenAI model.
 
         Args:
@@ -78,10 +78,11 @@ class OpenAIModelSetup:
                 The model ID.
 
         Returns:
-            Whether the model exists on OpenAI.
+            Whether the model exists on OpenAI, or the name of an extra that needs to
+            be installed to check if the model exists.
         """
         if openai is None:
-            raise NeedsExtraInstalled(extra="openai")
+            return "openai"
 
         all_models: list[openai.models.Model] = list(openai.models.list())
         return model_id in [model.id for model in all_models]

--- a/src/scandeval/protocols.py
+++ b/src/scandeval/protocols.py
@@ -204,7 +204,7 @@ class ModelSetup(Protocol):
         """
         ...
 
-    def model_exists(self, model_id: str) -> bool:
+    def model_exists(self, model_id: str) -> bool | str:
         """Check whether a model exists.
 
         Args:
@@ -212,7 +212,8 @@ class ModelSetup(Protocol):
                 The model ID.
 
         Returns:
-            Whether the model exists.
+            Whether the model exist, or the name of an extra that needs to be installed
+            to check if the model exists.
         """
         ...
 


### PR DESCRIPTION
### Fixed
- There was an error caused if an old version of the `openai` package was installed and
  if the `scandeval` package was checking if a model exists as an OpenAI model. Now an
  informative error is thrown if the model is not found on any available platforms, as
  well as noting the extras that are missing, which prevents the package from checking
  existence on those platforms.