### PR TITLE
Add arguments to `Benchmarker.benchmark`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+- Added arguments to `Benchmarker.benchmark` (or simply `Benchmarker.__call_`),
+  corresponding to the same arguments during initialisation. The idea here is that the
+  default parameters are set during initialisation, and then any of these can be
+  changed if needed when performing a concrete evaluation, without having to
+  re-initialise the `Benchmarker`.
+
+
 ## [v10.0.1] - 2024-02-12
 ### Fixed
 - A prefix space was added to labels in sequence classification tasks that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   changed if needed when performing a concrete evaluation, without having to
   re-initialise the `Benchmarker`.
 
+### Changed
+- The default value of the languages are now all languages, rather than only Danish,
+  Swedish and Norwegian.
+
 ### Fixed
 - There was an error caused if an old version of the `openai` package was installed and
   if the `scandeval` package was checking if a model exists as an OpenAI model. Now an

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -4,28 +4,33 @@ import os
 
 import torch
 
-from .config import BenchmarkConfig, DatasetTask, Language
-from .dataset_tasks import get_all_dataset_tasks
+from scandeval.dataset_configs import get_all_dataset_configs
+from scandeval.exceptions import InvalidBenchmark
+
+from .config import BenchmarkConfig, Language, Task
 from .enums import Device, Framework
 from .languages import get_all_languages
+from .tasks import get_all_tasks
 
 
 def build_benchmark_config(
+    progress_bar: bool,
+    save_results: bool,
+    task: str | list[str] | None,
+    dataset: str | list[str] | None,
     language: str | list[str],
     model_language: str | list[str] | None,
     dataset_language: str | list[str] | None,
-    dataset_task: str | list[str] | None,
-    batch_size: int,
-    raise_errors: bool,
-    cache_dir: str,
-    evaluate_train: bool,
-    token: bool | str,
-    openai_api_key: str | None,
-    progress_bar: bool,
-    save_results: bool,
-    verbose: bool,
     framework: Framework | str | None,
     device: Device | None,
+    batch_size: int,
+    evaluate_train: bool,
+    raise_errors: bool,
+    cache_dir: str,
+    token: bool | str,
+    openai_api_key: str | None,
+    force: bool,
+    verbose: bool,
     trust_remote_code: bool,
     load_in_4bit: bool | None,
     use_flash_attention: bool,
@@ -36,63 +41,64 @@ def build_benchmark_config(
     """Create a benchmark configuration.
 
     Args:
+        progress_bar:
+            Whether to show a progress bar when running the benchmark.
+        save_results:
+            Whether to save the benchmark results to a file.
+        task:
+            The tasks to include for dataset. If None then datasets will not be
+            filtered based on their task.
+        dataset:
+            The datasets to include for task. If None then all datasets will be
+            included, limited by the `task` parameter.
         language:
             The language codes of the languages to include, both for models and
             datasets. Here 'no' means both Bokmål (nb) and Nynorsk (nn). Set this
             to 'all' if all languages (also non-Scandinavian) should be considered.
         model_language:
-            The language codes of the languages to include for models. If specified
-            then this overrides the `language` parameter for model languages.
+            The language codes of the languages to include for models. If None then
+            the `language` parameter will be used.
         dataset_language:
-            The language codes of the languages to include for datasets. If
-            specified then this overrides the `language` parameter for dataset
-            languages.
-        dataset_task:
-            The tasks to include for dataset. If None then datasets will not be
-            filtered based on their task.
-        batch_size:
-            The batch size to use.
-        raise_errors:
-            Whether to raise errore instead of skipping them.
-        cache_dir:
-            Directory to store cached models.
-        evaluate_train:
-            Whether to evaluate the training set as well.
-        token:
-            The authentication token for the Hugging Face Hub. If a boolean value is
-            specified then the token will be fetched from the Hugging Face CLI, where
-            the user has logged in through `huggingface-cli login`. If a string is
-            specified then it will be used as the token.
-        openai_api_key:
-            The OpenAI API key to use for authentication. If None, then None will be
-            returned.
-        progress_bar:
-            Whether progress bars should be shown.
-        save_results:
-            Whether to save the benchmark results to local JSON file.
-        verbose:
-            Whether to output additional output.
+            The language codes of the languages to include for datasets. If None then
+            the `language` parameter will be used.
         framework:
-            The model framework to use. If None then the framework will be set
-            automatically. Only relevant if `model_id` refers to a local model.
+            The framework to use for running the models. If None then the framework
+            will be set automatically.
         device:
             The device to use for running the models. If None then the device will be
             set automatically.
+        batch_size:
+            The batch size to use for running the models.
+        evaluate_train:
+            Whether to evaluate the models on the training set.
+        raise_errors:
+            Whether to raise errors when running the benchmark.
+        cache_dir:
+            The directory to use for caching the models.
+        token:
+            The token to use for running the models.
+        openai_api_key:
+            The OpenAI API key to use for running the models.
+        force:
+            Whether to force the benchmark to run even if the results are already
+            cached.
+        verbose:
+            Whether to print verbose output when running the benchmark.
         trust_remote_code:
-            Whether to trust remote code when loading models from the Hugging Face
-            Hub.
+            Whether to trust remote code when running the benchmark.
         load_in_4bit:
-            Whether to load models in 4-bit precision. If None then this will be done
-            if CUDA is available and the model is a decoder model. Defaults to None.
+            Whether to load the models in 4-bit precision.
         use_flash_attention:
-            Whether to use Flash Attention.
+            Whether to use Flash Attention for the models.
         clear_model_cache:
-            Whether to clear the model cache after benchmarking each model.
+            Whether to clear the model cache before running the benchmark.
         only_validation_split:
-            Whether to only evaluate on the validation split.
+            Whether to only use the validation split for the datasets.
         few_shot:
-            Whether to only evaluate the model using few-shot evaluation. Only relevant
-            if the model is generative.
+            Whether to use few-shot learning for the models.
+
+    Returns:
+        The benchmark configuration.
     """
     language_codes = get_correct_language_codes(language_codes=language)
     model_languages = prepare_languages(
@@ -102,7 +108,7 @@ def build_benchmark_config(
         language_codes=dataset_language, default_language_codes=language_codes
     )
 
-    dataset_tasks = prepare_dataset_tasks(dataset_task=dataset_task)
+    tasks, datasets = prepare_tasks_and_datasets(task=task, dataset=dataset)
 
     torch_device = prepare_device(device=device)
 
@@ -114,13 +120,15 @@ def build_benchmark_config(
     return BenchmarkConfig(
         model_languages=model_languages,
         dataset_languages=dataset_languages,
-        dataset_tasks=dataset_tasks,
+        tasks=tasks,
+        datasets=datasets,
         batch_size=batch_size,
         raise_errors=raise_errors,
         cache_dir=cache_dir,
         evaluate_train=evaluate_train,
         token=token,
         openai_api_key=openai_api_key,
+        force=force,
         progress_bar=progress_bar,
         save_results=save_results,
         verbose=verbose,
@@ -205,30 +213,49 @@ def prepare_languages(
     return prepared_languages
 
 
-def prepare_dataset_tasks(dataset_task: str | list[str] | None) -> list[DatasetTask]:
-    """Prepare dataset task(s) for benchmarking.
+def prepare_tasks_and_datasets(
+    task: str | list[str] | None, dataset: str | list[str] | None
+) -> tuple[list[Task], list[str]]:
+    """Prepare task(s) and dataset(s) for benchmarking.
 
     Args:
-        dataset_task:
+        task:
             The tasks to include for dataset. If None then datasets will not be
             filtered based on their task.
+        dataset:
+            The datasets to include for task. If None then all datasets will be
+            included, limited by the `task` parameter.
 
     Returns:
-        The prepared dataset tasks.
+        The prepared tasks and datasets.
     """
     # Create a dictionary that maps benchmark tasks to their associated benchmark
-    # task objects
-    dataset_task_mapping = get_all_dataset_tasks()
+    # task objects, and a dictionary that maps dataset names to their associated
+    # dataset configuration objects
+    task_mapping = get_all_tasks()
+    all_dataset_configs = get_all_dataset_configs()
 
     # Create the list of dataset tasks
-    if dataset_task is None:
-        dataset_tasks = list(dataset_task_mapping.values())
-    elif isinstance(dataset_task, str):
-        dataset_tasks = [dataset_task_mapping[dataset_task]]
-    else:
-        dataset_tasks = [dataset_task_mapping[task] for task in dataset_task]
+    try:
+        if task is None:
+            tasks = list(task_mapping.values())
+        elif isinstance(task, str):
+            tasks = [task_mapping[task]]
+        else:
+            tasks = [task_mapping[task] for task in task]
+    except KeyError as e:
+        raise InvalidBenchmark(f"Task {e} not found in the benchmark tasks.") from e
 
-    return dataset_tasks
+    # Create the list of dataset names
+    if dataset is None:
+        dataset = list(all_dataset_configs.keys())
+    datasets = [
+        dataset_name
+        for dataset_name, dataset_config in all_dataset_configs.items()
+        if dataset_name in dataset and dataset_config.task in tasks
+    ]
+
+    return tasks, datasets
 
 
 def prepare_device(device: Device | None) -> torch.device:

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -252,7 +252,7 @@ def prepare_tasks_and_datasets(
         elif isinstance(task, str):
             tasks = [task_mapping[task]]
         else:
-            tasks = [task_mapping[task] for task in task]
+            tasks = [task_mapping[t] for t in task]
     except KeyError as e:
         raise InvalidBenchmark(f"Task {e} not found in the benchmark tasks.") from e
 

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -108,7 +108,9 @@ def build_benchmark_config(
         language_codes=dataset_language, default_language_codes=language_codes
     )
 
-    tasks, datasets = prepare_tasks_and_datasets(task=task, dataset=dataset)
+    tasks, datasets = prepare_tasks_and_datasets(
+        task=task, dataset=dataset, dataset_languages=dataset_languages
+    )
 
     torch_device = prepare_device(device=device)
 
@@ -144,7 +146,7 @@ def build_benchmark_config(
 
 
 def get_correct_language_codes(language_codes: str | list[str]) -> list[str]:
-    """Get correct language-code(s).
+    """Get correct language code(s).
 
     Args:
         language_codes:
@@ -153,7 +155,7 @@ def get_correct_language_codes(language_codes: str | list[str]) -> list[str]:
             to 'all' if all languages (also non-Scandinavian) should be considered.
 
     Returns:
-        The correct language-codes.
+        The correct language codes.
     """
     # Create a dictionary that maps languages to their associated language objects
     language_mapping = get_all_languages()
@@ -214,7 +216,9 @@ def prepare_languages(
 
 
 def prepare_tasks_and_datasets(
-    task: str | list[str] | None, dataset: str | list[str] | None
+    task: str | list[str] | None,
+    dataset_languages: list[Language],
+    dataset: str | list[str] | None,
 ) -> tuple[list[Task], list[str]]:
     """Prepare task(s) and dataset(s) for benchmarking.
 
@@ -222,9 +226,11 @@ def prepare_tasks_and_datasets(
         task:
             The tasks to include for dataset. If None then datasets will not be
             filtered based on their task.
+        dataset_languages:
+            The languages of the datasets in the benchmark.
         dataset:
             The datasets to include for task. If None then all datasets will be
-            included, limited by the `task` parameter.
+            included, limited by the `task` and `dataset_languages` parameters.
 
     Returns:
         The prepared tasks and datasets.
@@ -263,11 +269,12 @@ def prepare_tasks_and_datasets(
             "datasets."
         )
 
-    # Create the list of dataset names
     datasets = [
         dataset_name
         for dataset_name, dataset_config in all_dataset_configs.items()
-        if dataset_name in dataset and dataset_config.task in tasks
+        if dataset_name in dataset
+        and dataset_config.task in tasks
+        and set(dataset_config.languages).intersection(dataset_languages)
     ]
 
     return tasks, datasets

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -228,6 +228,10 @@ def prepare_tasks_and_datasets(
 
     Returns:
         The prepared tasks and datasets.
+
+    Raises:
+        InvalidBenchmark:
+            If the task or dataset is not found in the benchmark tasks or datasets.
     """
     # Create a dictionary that maps benchmark tasks to their associated benchmark
     # task objects, and a dictionary that maps dataset names to their associated
@@ -246,9 +250,20 @@ def prepare_tasks_and_datasets(
     except KeyError as e:
         raise InvalidBenchmark(f"Task {e} not found in the benchmark tasks.") from e
 
-    # Create the list of dataset names
+    all_datasets = list(all_dataset_configs.keys())
     if dataset is None:
-        dataset = list(all_dataset_configs.keys())
+        dataset = all_datasets
+    elif isinstance(dataset, str):
+        dataset = [dataset]
+
+    invalid_datasets = set(dataset) - set(all_datasets)
+    if invalid_datasets:
+        raise InvalidBenchmark(
+            f"Dataset(s) {', '.join(invalid_datasets)} not found in the benchmark "
+            "datasets."
+        )
+
+    # Create the list of dataset names
     datasets = [
         dataset_name
         for dataset_name, dataset_config in all_dataset_configs.items()

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -21,7 +21,6 @@ from transformers import PretrainedConfig, Trainer
 from transformers.modeling_utils import ModelOutput, PreTrainedModel
 
 from .config import BenchmarkConfig, DatasetConfig, ModelConfig
-from .dataset_tasks import SPEED
 from .exceptions import InvalidBenchmark
 from .finetuning import finetune
 from .generation import generate
@@ -31,6 +30,7 @@ from .openai_models import OpenAIModel
 from .protocols import GenerativeModel, Tokenizer
 from .scores import log_scores
 from .speed_benchmark import benchmark_speed
+from .tasks import SPEED
 from .types import Labels, Predictions, ScoreDict
 from .utils import (
     GENERATIVE_MODEL_TASKS,

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -247,6 +247,7 @@ def benchmark(
         model_language=model_languages,
         dataset_language=dataset_languages,
         task=tasks,
+        dataset=datasets,
         batch_size=batch_size_int,
         progress_bar=progress_bar,
         save_results=save_results,
@@ -267,7 +268,7 @@ def benchmark(
     )
 
     # Perform the benchmark evaluation
-    benchmarker(model=models, dataset=datasets)
+    benchmarker(model=models)
 
 
 if __name__ == "__main__":

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -4,9 +4,9 @@ import click
 
 from .benchmarker import Benchmarker
 from .dataset_configs import get_all_dataset_configs
-from .dataset_tasks import get_all_dataset_tasks
 from .enums import Device, Framework
 from .languages import get_all_languages
+from .tasks import get_all_tasks
 
 
 @click.command()
@@ -28,7 +28,7 @@ from .languages import get_all_languages
     default=None,
     show_default=True,
     multiple=True,
-    type=click.Choice(list(get_all_dataset_tasks().keys())),
+    type=click.Choice(list(get_all_tasks().keys())),
     help="The dataset tasks to benchmark the model(s) on.",
 )
 @click.option(

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -34,7 +34,7 @@ from .tasks import get_all_tasks
 @click.option(
     "--language",
     "-l",
-    default=["da", "sv", "no"],
+    default=["all"],
     show_default=True,
     multiple=True,
     metavar="ISO 639-1 LANGUAGE CODE",

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -43,7 +43,7 @@ class MetricConfig:
 
 
 @dataclass
-class DatasetTask:
+class Task:
     """A dataset task.
 
     Attributes:
@@ -87,8 +87,10 @@ class BenchmarkConfig:
             The languages of the models to benchmark.
         dataset_languages:
             The languages of the datasets in the benchmark.
-        dataset_tasks:
-            The tasks to benchmark.
+        tasks:
+            The tasks benchmark the model(s) on.
+        datasets:
+            The datasets to benchmark on.
         framework:
             The framework of the models to benchmark. If None then the framework will be
             inferred.
@@ -108,6 +110,9 @@ class BenchmarkConfig:
         openai_api_key:
             The API key for the OpenAI API. If None then OpenAI models will not be
             benchmarked.
+        force:
+            Whether to force the benchmark to run even if the results are already
+            cached.
         progress_bar:
             Whether to show a progress bar.
         save_results:
@@ -134,7 +139,8 @@ class BenchmarkConfig:
 
     model_languages: list[Language]
     dataset_languages: list[Language]
-    dataset_tasks: list[DatasetTask]
+    tasks: list[Task]
+    datasets: list[str]
     framework: Framework | None
     batch_size: int
     raise_errors: bool
@@ -142,6 +148,7 @@ class BenchmarkConfig:
     evaluate_train: bool
     token: bool | str
     openai_api_key: str | None
+    force: bool
     progress_bar: bool
     save_results: bool
     device: torch.device
@@ -196,7 +203,7 @@ class DatasetConfig:
     name: str
     pretty_name: str
     huggingface_id: str
-    task: DatasetTask
+    task: Task
     languages: list[Language]
     prompt_template: str
     max_generated_tokens: int

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -41,6 +41,10 @@ class MetricConfig:
         default_factory=lambda: lambda raw_score: (100 * raw_score, f"{raw_score:.2%}")
     )
 
+    def __hash__(self) -> int:
+        """Return a hash of the metric configuration."""
+        return hash(self.name)
+
 
 @dataclass
 class Task:
@@ -62,6 +66,10 @@ class Task:
     metrics: list[MetricConfig]
     labels: list[str]
 
+    def __hash__(self) -> int:
+        """Return a hash of the task."""
+        return hash(self.name)
+
 
 @dataclass
 class Language:
@@ -76,6 +84,10 @@ class Language:
 
     code: str
     name: str
+
+    def __hash__(self) -> int:
+        """Return a hash of the language."""
+        return hash(self.code)
 
 
 @dataclass
@@ -226,6 +238,10 @@ class DatasetConfig:
         """The number of labels in the dataset."""
         return len(self.task.labels)
 
+    def __hash__(self) -> int:
+        """Return a hash of the dataset configuration."""
+        return hash(self.name)
+
 
 @dataclass
 class ModelConfig:
@@ -255,3 +271,7 @@ class ModelConfig:
     languages: list[Language]
     model_type: ModelType | str
     model_cache_dir: str
+
+    def __hash__(self) -> int:
+        """Return a hash of the model configuration."""
+        return hash(self.model_id)

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -1,8 +1,8 @@
 """All dataset configurations used in ScandEval."""
 
 from .config import DatasetConfig
-from .dataset_tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SPEED, SUMM
 from .languages import DA, DE, EN, FO, IS, NB, NL, NN, SV, get_all_languages
+from .tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SPEED, SUMM
 
 
 def get_all_dataset_configs() -> dict[str, DatasetConfig]:

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -20,7 +20,6 @@ from transformers import (
 from transformers.modeling_utils import ModelOutput
 
 from .config import BenchmarkConfig, DatasetConfig, ModelConfig
-from .dataset_tasks import NER
 from .exceptions import InvalidBenchmark, NeedsExtraInstalled
 from .model_cache import (
     ModelCache,
@@ -29,6 +28,7 @@ from .model_cache import (
 )
 from .openai_models import OpenAIModel
 from .protocols import GenerativeModel, Tokenizer
+from .tasks import NER
 from .utils import SUPERTASKS_USING_LOGPROBS, clear_memory, get_ner_parser
 from .vllm_models import VLLMModel
 

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -1,18 +1,18 @@
 """All benchmarks tasks used in ScandEval."""
 
-from .config import DatasetTask, MetricConfig
+from .config import MetricConfig, Task
 
 
-def get_all_dataset_tasks() -> dict[str, DatasetTask]:
+def get_all_tasks() -> dict[str, Task]:
     """Get a list of all the dataset tasks.
 
     Returns:
         A mapping between names of dataset tasks and their configurations.
     """
-    return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, DatasetTask)}
+    return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, Task)}
 
 
-LA = DatasetTask(
+LA = Task(
     name="linguistic-acceptability",
     supertask="sequence-classification",
     metrics=[
@@ -34,7 +34,7 @@ LA = DatasetTask(
 )
 
 
-NER = DatasetTask(
+NER = Task(
     name="named-entity-recognition",
     supertask="token-classification",
     metrics=[
@@ -65,7 +65,7 @@ NER = DatasetTask(
 )
 
 
-QA = DatasetTask(
+QA = Task(
     name="question-answering",
     supertask="question-answering",
     metrics=[
@@ -88,7 +88,7 @@ QA = DatasetTask(
 )
 
 
-SENT = DatasetTask(
+SENT = Task(
     name="sentiment-classification",
     supertask="sequence-classification",
     metrics=[
@@ -110,7 +110,7 @@ SENT = DatasetTask(
 )
 
 
-SUMM = DatasetTask(
+SUMM = Task(
     name="summarization",
     supertask="text-to-text",
     metrics=[
@@ -132,7 +132,7 @@ SUMM = DatasetTask(
 )
 
 
-KNOW = DatasetTask(
+KNOW = Task(
     name="knowledge",
     supertask="sequence-classification",
     metrics=[
@@ -153,7 +153,7 @@ KNOW = DatasetTask(
 )
 
 
-COMMON_SENSE = DatasetTask(
+COMMON_SENSE = Task(
     name="common-sense-reasoning",
     supertask="sequence-classification",
     metrics=[
@@ -174,7 +174,7 @@ COMMON_SENSE = DatasetTask(
 )
 
 
-TEXT_MODELLING = DatasetTask(
+TEXT_MODELLING = Task(
     name="text-modelling",
     supertask="text-modelling",
     metrics=[
@@ -189,7 +189,7 @@ TEXT_MODELLING = DatasetTask(
 )
 
 
-SPEED = DatasetTask(
+SPEED = Task(
     name="speed",
     supertask="sequence-classification",
     metrics=[

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -13,7 +13,7 @@ from transformers import GenerationConfig, PretrainedConfig, PreTrainedTokenizer
 from transformers.utils import ModelOutput
 
 from .config import DatasetConfig, ModelConfig
-from .dataset_tasks import NER
+from .tasks import NER
 from .utils import clear_memory, get_ner_parser
 
 logger = logging.getLogger(__package__)

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -4,13 +4,13 @@ import pytest
 import torch
 from scandeval.benchmark_config_factory import (
     get_correct_language_codes,
-    prepare_dataset_tasks,
     prepare_device,
     prepare_languages,
+    prepare_tasks_and_datasets,
 )
-from scandeval.dataset_tasks import LA, NER, get_all_dataset_tasks
 from scandeval.enums import Device
 from scandeval.languages import DA, EN, NB, NN, NO, get_all_languages
+from scandeval.tasks import LA, NER, get_all_tasks
 
 
 @pytest.mark.parametrize(
@@ -75,16 +75,16 @@ def test_prepare_languages(input_language_codes, input_language, expected_langua
 @pytest.mark.parametrize(
     argnames=["input_task", "expected_task"],
     argvalues=[
-        (None, list(get_all_dataset_tasks().values())),
+        (None, list(get_all_tasks().values())),
         ("linguistic-acceptability", [LA]),
         (["linguistic-acceptability"], [LA]),
         (["linguistic-acceptability", "named-entity-recognition"], [LA, NER]),
     ],
     ids=["all tasks", "single task", "single task as list", "multiple tasks"],
 )
-def test_prepare_dataset_tasks(input_task, expected_task):
-    """Test the output of `prepare_dataset_tasks`."""
-    prepared_tasks = prepare_dataset_tasks(dataset_task=input_task)
+def test_prepare_tasks_and_datasets(input_task, expected_task):
+    """Test the output of `prepare_tasks_and_datasets`."""
+    prepared_tasks = prepare_tasks_and_datasets(task=input_task, dataset=None)
     assert prepared_tasks == expected_task
 
 

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -94,14 +94,14 @@ def test_prepare_languages(input_language_codes, input_language, expected_langua
         (
             ["linguistic-acceptability", "named-entity-recognition"],
             "scala-da",
-            [LA, NER],
-            ["scala-da"],
+            {LA, NER},
+            {"scala-da"},
         ),
         (
             ["linguistic-acceptability", "sentiment-classification"],
             ["scala-da", "angry-tweets", "scandiqa-da"],
-            [LA, SENT],
-            ["scala-da", "angry-tweets"],
+            {LA, SENT},
+            {"scala-da", "angry-tweets"},
         ),
     ],
     ids=[
@@ -120,8 +120,8 @@ def test_prepare_tasks_and_datasets(
     prepared_tasks, prepared_datasets = prepare_tasks_and_datasets(
         task=input_task, dataset=input_dataset
     )
-    assert prepared_tasks == expected_task
-    assert prepared_datasets == expected_dataset
+    assert set(prepared_tasks) == expected_task
+    assert set(prepared_datasets) == expected_dataset
 
 
 def test_prepare_tasks_and_datasets_invalid_task():

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -120,8 +120,8 @@ def test_prepare_tasks_and_datasets(
     prepared_tasks, prepared_datasets = prepare_tasks_and_datasets(
         task=input_task, dataset=input_dataset
     )
-    assert set(prepared_tasks) == expected_task
-    assert set(prepared_datasets) == expected_dataset
+    assert set(prepared_tasks) == set(expected_task)
+    assert set(prepared_datasets) == set(expected_dataset)
 
 
 def test_prepare_tasks_and_datasets_invalid_task():

--- a/tests/test_benchmark_config_factory.py
+++ b/tests/test_benchmark_config_factory.py
@@ -75,33 +75,69 @@ def test_prepare_languages(input_language_codes, input_language, expected_langua
 
 
 @pytest.mark.parametrize(
-    argnames=["input_task", "input_dataset", "expected_task", "expected_dataset"],
+    argnames=[
+        "input_task",
+        "input_dataset",
+        "input_languages",
+        "expected_task",
+        "expected_dataset",
+    ],
     argvalues=[
         (
             None,
             None,
+            list(get_all_languages().values()),
             list(get_all_tasks().values()),
             list(get_all_dataset_configs().keys()),
         ),
         (
             "linguistic-acceptability",
             None,
+            list(get_all_languages().values()),
             [LA],
             [cfg.name for cfg in get_all_dataset_configs().values() if LA == cfg.task],
         ),
-        (None, "scala-da", list(get_all_tasks().values()), ["scala-da"]),
-        ("linguistic-acceptability", ["scala-da", "angry-tweets"], [LA], ["scala-da"]),
+        (
+            None,
+            "scala-da",
+            list(get_all_languages().values()),
+            list(get_all_tasks().values()),
+            ["scala-da"],
+        ),
+        (
+            "linguistic-acceptability",
+            ["scala-da", "angry-tweets"],
+            list(get_all_languages().values()),
+            [LA],
+            ["scala-da"],
+        ),
         (
             ["linguistic-acceptability", "named-entity-recognition"],
             "scala-da",
-            {LA, NER},
-            {"scala-da"},
+            list(get_all_languages().values()),
+            [LA, NER],
+            ["scala-da"],
         ),
         (
             ["linguistic-acceptability", "sentiment-classification"],
             ["scala-da", "angry-tweets", "scandiqa-da"],
-            {LA, SENT},
-            {"scala-da", "angry-tweets"},
+            list(get_all_languages().values()),
+            [LA, SENT],
+            ["scala-da", "angry-tweets"],
+        ),
+        (
+            ["linguistic-acceptability", "sentiment-classification"],
+            ["scala-da", "angry-tweets", "scandiqa-sv"],
+            [DA],
+            [LA, SENT],
+            ["scala-da", "angry-tweets"],
+        ),
+        (
+            ["linguistic-acceptability", "sentiment-classification"],
+            None,
+            [DA],
+            [LA, SENT],
+            ["scala-da", "angry-tweets"],
         ),
     ],
     ids=[
@@ -111,14 +147,16 @@ def test_prepare_languages(input_language_codes, input_language, expected_langua
         "single task and multiple datasets",
         "multiple tasks and single dataset",
         "multiple tasks and datasets",
+        "multiple tasks and datasets, filtered by language",
+        "multiple tasks, filtered by language",
     ],
 )
 def test_prepare_tasks_and_datasets(
-    input_task, input_dataset, expected_task, expected_dataset
+    input_task, input_dataset, input_languages, expected_task, expected_dataset
 ):
     """Test the output of `prepare_tasks_and_datasets`."""
     prepared_tasks, prepared_datasets = prepare_tasks_and_datasets(
-        task=input_task, dataset=input_dataset
+        task=input_task, dataset=input_dataset, dataset_languages=input_languages
     )
     assert set(prepared_tasks) == set(expected_task)
     assert set(prepared_datasets) == set(expected_dataset)
@@ -127,13 +165,17 @@ def test_prepare_tasks_and_datasets(
 def test_prepare_tasks_and_datasets_invalid_task():
     """Test that an invalid task raises an error."""
     with pytest.raises(InvalidBenchmark):
-        prepare_tasks_and_datasets(task="invalid-task", dataset=None)
+        prepare_tasks_and_datasets(
+            task="invalid-task", dataset=None, dataset_languages=[DA]
+        )
 
 
 def test_prepare_tasks_and_datasets_invalid_dataset():
     """Test that an invalid dataset raises an error."""
     with pytest.raises(InvalidBenchmark):
-        prepare_tasks_and_datasets(task=None, dataset="invalid-dataset")
+        prepare_tasks_and_datasets(
+            task=None, dataset="invalid-dataset", dataset_languages=[DA]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,7 @@ from scandeval.config import (
     ModelConfig,
     Task,
 )
-from scandeval.enums import ModelType
+from scandeval.enums import Framework, ModelType
 
 
 class TestMetricConfig:
@@ -152,7 +152,7 @@ class TestModelConfig:
         """Test that the model config attributes correspond to the arguments."""
         assert model_config.model_id == "model_id"
         assert model_config.revision == "revision"
-        assert model_config.framework == "framework"
+        assert model_config.framework == Framework.PYTORCH
         assert model_config.task == "task"
         assert model_config.languages == [language]
         assert model_config.model_type == ModelType.FRESH

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,10 @@ import pytest
 from scandeval.config import (
     BenchmarkConfig,
     DatasetConfig,
-    DatasetTask,
     Language,
     MetricConfig,
     ModelConfig,
+    Task,
 )
 from scandeval.enums import ModelType
 
@@ -47,18 +47,18 @@ class TestMetricConfig:
         assert metric_config.postprocessing_fn(inputs) == expected
 
 
-class TestDatasetTask:
-    """Unit tests for the `DatasetTask` class."""
+class TestTask:
+    """Unit tests for the `Task` class."""
 
-    def test_dataset_task_is_object(self, dataset_task):
-        """Test that the dataset task is a `DatasetTask` object."""
-        assert isinstance(dataset_task, DatasetTask)
+    def test_task_is_object(self, task):
+        """Test that the dataset task is a `Task` object."""
+        assert isinstance(task, Task)
 
-    def test_attributes_correspond_to_arguments(self, dataset_task):
+    def test_attributes_correspond_to_arguments(self, task):
         """Test that the dataset task attributes correspond to the arguments."""
-        assert dataset_task.name == "speed"
-        assert dataset_task.supertask == "sequence-classification"
-        assert dataset_task.labels == []
+        assert task.name == "speed"
+        assert task.supertask == "sequence-classification"
+        assert task.labels == []
 
 
 class TestLanguage:
@@ -82,12 +82,12 @@ class TestBenchmarkConfig:
         assert isinstance(benchmark_config, BenchmarkConfig)
 
     def test_attributes_correspond_to_arguments(
-        self, benchmark_config, language, dataset_task, auth, device
+        self, benchmark_config, language, task, auth, device
     ):
         """Test that the benchmark config attributes correspond to the arguments."""
         assert benchmark_config.model_languages == [language]
         assert benchmark_config.dataset_languages == [language]
-        assert benchmark_config.dataset_tasks == [dataset_task]
+        assert benchmark_config.tasks == [task]
         assert benchmark_config.framework is None
         assert benchmark_config.batch_size == 32
         assert benchmark_config.raise_errors is False
@@ -114,14 +114,12 @@ class TestDatasetConfig:
         """Test that the dataset config is a `DatasetConfig` object."""
         assert isinstance(dataset_config, DatasetConfig)
 
-    def test_attributes_correspond_to_arguments(
-        self, dataset_config, language, dataset_task
-    ):
+    def test_attributes_correspond_to_arguments(self, dataset_config, language, task):
         """Test that the dataset config attributes correspond to the arguments."""
         assert dataset_config.name == "dataset_name"
         assert dataset_config.pretty_name == "Dataset name"
         assert dataset_config.huggingface_id == "dataset_id"
-        assert dataset_config.task == dataset_task
+        assert dataset_config.task == task
         assert dataset_config.languages == [language]
         assert dataset_config.prompt_template == "{text}\n{label}"
         assert dataset_config.max_generated_tokens == 1

--- a/tests/test_dataset_factory.py
+++ b/tests/test_dataset_factory.py
@@ -5,10 +5,10 @@ from typing import Generator
 
 import pytest
 from scandeval.dataset_factory import DatasetFactory
-from scandeval.dataset_tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SUMM
 from scandeval.named_entity_recognition import NamedEntityRecognition
 from scandeval.question_answering import QuestionAnswering
 from scandeval.sequence_classification import SequenceClassification
+from scandeval.tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SUMM
 from scandeval.text_to_text import TextToText
 
 

--- a/tests/test_dataset_tasks.py
+++ b/tests/test_dataset_tasks.py
@@ -1,31 +1,31 @@
-"""Unit tests for the `dataset_tasks` module."""
+"""Unit tests for the `tasks` module."""
 
 from typing import Generator
 
 import pytest
-from scandeval.config import DatasetTask
-from scandeval.dataset_tasks import get_all_dataset_tasks
+from scandeval.config import Task
+from scandeval.tasks import get_all_tasks
 
 
-class TestGetAllDatasetTasks:
-    """Unit tests for the `get_all_dataset_tasks` function."""
+class TestGetAllTasks:
+    """Unit tests for the `get_all_tasks` function."""
 
     @pytest.fixture(scope="class")
-    def dataset_tasks(self) -> Generator[dict[str, DatasetTask], None, None]:
+    def tasks(self) -> Generator[dict[str, Task], None, None]:
         """Yields all dataset tasks."""
-        yield get_all_dataset_tasks()
+        yield get_all_tasks()
 
-    def test_dataset_tasks_is_dict(self, dataset_tasks):
+    def test_tasks_is_dict(self, tasks):
         """Tests that the dataset tasks are a dictionary."""
-        assert isinstance(dataset_tasks, dict)
+        assert isinstance(tasks, dict)
 
-    def test_dataset_tasks_are_objects(self, dataset_tasks):
+    def test_tasks_are_objects(self, tasks):
         """Tests that the dataset tasks are objects."""
-        for dataset_task in dataset_tasks.values():
-            assert isinstance(dataset_task, DatasetTask)
+        for task in tasks.values():
+            assert isinstance(task, Task)
 
     @pytest.mark.parametrize(
-        "dataset_task_name",
+        "task_name",
         [
             "linguistic-acceptability",
             "named-entity-recognition",
@@ -38,6 +38,6 @@ class TestGetAllDatasetTasks:
             "speed",
         ],
     )
-    def test_get_task(self, dataset_tasks, dataset_task_name):
+    def test_get_task(self, tasks, task_name):
         """Tests that the dataset task can be retrieved by name."""
-        assert dataset_task_name in dataset_tasks
+        assert task_name in tasks


### PR DESCRIPTION
### Added
- Added arguments to `Benchmarker.benchmark` (or simply `Benchmarker.__call_`),
  corresponding to the same arguments during initialisation. The idea here is that the
  default parameters are set during initialisation, and then any of these can be
  changed if needed when performing a concrete evaluation, without having to
  re-initialise the `Benchmarker`.

### Changed
- The default value of the languages are now all languages, rather than only Danish,
  Swedish and Norwegian.

Closes #229 