### PR TITLE
Fix/197 lmformatenforcer problem when benchmarking on ner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   informative error is thrown if the model is not found on any available platforms, as
   well as noting the extras that are missing, which prevents the package from checking
   existence on those platforms.
+- Disabled `lmformatenforcer` logging, which happens in the rare case when we're
+  few-shot evaluating a model on NER and there are no JSON-valid tokens to generate.
 
 
 ## [v10.0.1] - 2024-02-12

--- a/src/scandeval/__init__.py
+++ b/src/scandeval/__init__.py
@@ -24,7 +24,11 @@ load_dotenv()
 
 
 # Set up logging
-fmt = colored("%(asctime)s", "light_blue") + " ⋅ " + colored("%(message)s", "green")
+fmt = (
+    colored("%(asctime)s - %(name)s", "light_blue")
+    + " ⋅ "
+    + colored("%(message)s", "green")
+)
 logging.basicConfig(
     level=logging.CRITICAL if hasattr(sys, "_called_from_test") else logging.INFO,
     format=fmt,

--- a/src/scandeval/__init__.py
+++ b/src/scandeval/__init__.py
@@ -24,11 +24,7 @@ load_dotenv()
 
 
 # Set up logging
-fmt = (
-    colored("%(asctime)s - %(name)s", "light_blue")
-    + " ⋅ "
-    + colored("%(message)s", "green")
-)
+fmt = colored("%(asctime)s", "light_blue") + " ⋅ " + colored("%(message)s", "green")
 logging.basicConfig(
     level=logging.CRITICAL if hasattr(sys, "_called_from_test") else logging.INFO,
     format=fmt,

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -180,6 +180,7 @@ def block_terminal_output():
     logging.getLogger("vllm.core.scheduler").setLevel(logging.ERROR)
     logging.getLogger("vllm.model_executor.weight_utils").setLevel(logging.ERROR)
     logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("root").setLevel(logging.ERROR)  # For `lmformatenforcer` package
 
     def init_vllm_logger(name: str):
         """Dummy function to initialise vLLM loggers with the ERROR level."""

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -169,23 +169,25 @@ def block_terminal_output():
     warnings.filterwarnings("ignore", module="seqeval*")
 
     # Up the logging level, to disable outputs
-    logging.getLogger("filelock").setLevel(logging.ERROR)
-    logging.getLogger("absl").setLevel(logging.ERROR)
-    logging.getLogger("datasets").setLevel(logging.ERROR)
-    logging.getLogger("openai").setLevel(logging.ERROR)
-    logging.getLogger("torch.distributed.distributed_c10d").setLevel(logging.ERROR)
-    logging.getLogger("torch.nn.parallel.distributed").setLevel(logging.ERROR)
-    logging.getLogger("vllm.engine.llm_engine").setLevel(logging.ERROR)
-    logging.getLogger("vllm.transformers_utils.tokenizer").setLevel(logging.ERROR)
-    logging.getLogger("vllm.core.scheduler").setLevel(logging.ERROR)
-    logging.getLogger("vllm.model_executor.weight_utils").setLevel(logging.ERROR)
-    logging.getLogger("httpx").setLevel(logging.ERROR)
-    logging.getLogger("root").setLevel(logging.ERROR)  # For `lmformatenforcer` package
+    logging.getLogger("filelock").setLevel(logging.CRITICAL)
+    logging.getLogger("absl").setLevel(logging.CRITICAL)
+    logging.getLogger("datasets").setLevel(logging.CRITICAL)
+    logging.getLogger("openai").setLevel(logging.CRITICAL)
+    logging.getLogger("torch.distributed.distributed_c10d").setLevel(logging.CRITICAL)
+    logging.getLogger("torch.nn.parallel.distributed").setLevel(logging.CRITICAL)
+    logging.getLogger("vllm.engine.llm_engine").setLevel(logging.CRITICAL)
+    logging.getLogger("vllm.transformers_utils.tokenizer").setLevel(logging.CRITICAL)
+    logging.getLogger("vllm.core.scheduler").setLevel(logging.CRITICAL)
+    logging.getLogger("vllm.model_executor.weight_utils").setLevel(logging.CRITICAL)
+    logging.getLogger("httpx").setLevel(logging.CRITICAL)
+
+    # The `lmformatenforcer` uses the root logger, so we need to set the level of that
+    logging.getLogger("root").setLevel(logging.CRITICAL)
 
     def init_vllm_logger(name: str):
-        """Dummy function to initialise vLLM loggers with the ERROR level."""
+        """Dummy function to initialise vLLM loggers with the CRITICAL level."""
         vllm_logger = logging.getLogger(name)
-        vllm_logger.setLevel(logging.ERROR)
+        vllm_logger.setLevel(logging.CRITICAL)
         return vllm_logger
 
     try:

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -177,7 +177,6 @@ class VLLMModel:
         temperature = (
             0.0 if not generation_config.do_sample else generation_config.temperature
         )
-        breakpoint()
         sampling_params = SamplingParams(
             # What to output
             max_tokens=max_tokens,
@@ -210,16 +209,11 @@ class VLLMModel:
 
         # Generate sequences using vLLM
         input_is_a_test = len(prompts) == 1 and len(set(prompts[0])) == 1
-        try:
-            raw_outputs = self._model.generate(
-                prompts=prompts,
-                use_tqdm=(not input_is_a_test),
-                sampling_params=sampling_params,
-            )
-        except ValueError as e:
-            print(e)
-            breakpoint()
-            pass
+        raw_outputs = self._model.generate(
+            prompts=prompts,
+            use_tqdm=(not input_is_a_test),
+            sampling_params=sampling_params,
+        )
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -209,11 +209,16 @@ class VLLMModel:
 
         # Generate sequences using vLLM
         input_is_a_test = len(prompts) == 1 and len(set(prompts[0])) == 1
-        raw_outputs = self._model.generate(
-            prompts=prompts,
-            use_tqdm=(not input_is_a_test),
-            sampling_params=sampling_params,
-        )
+        try:
+            raw_outputs = self._model.generate(
+                prompts=prompts,
+                use_tqdm=(not input_is_a_test),
+                sampling_params=sampling_params,
+            )
+        except ValueError as e:
+            print(e)
+            breakpoint()
+            pass
 
         # Collect the generated sequences into a single tensor of shape
         # (batch_size, generated_sequence_length)
@@ -286,7 +291,6 @@ class VLLMModel:
 
         # Add JSON generation constraint if we are benchmarking the NER task
         if self.dataset_config.task == NER:
-            breakpoint()
             parser = get_ner_parser(dataset_config=self.dataset_config)
             tokenizer_data = build_vllm_token_enforcer_tokenizer_data(llm=self._model)
             logits_processor = build_vllm_logits_processor(

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -286,6 +286,7 @@ class VLLMModel:
 
         # Add JSON generation constraint if we are benchmarking the NER task
         if self.dataset_config.task == NER:
+            breakpoint()
             parser = get_ner_parser(dataset_config=self.dataset_config)
             tokenizer_data = build_vllm_token_enforcer_tokenizer_data(llm=self._model)
             logits_processor = build_vllm_logits_processor(

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -177,6 +177,7 @@ class VLLMModel:
         temperature = (
             0.0 if not generation_config.do_sample else generation_config.temperature
         )
+        breakpoint()
         sampling_params = SamplingParams(
             # What to output
             max_tokens=max_tokens,


### PR DESCRIPTION
### Fixed
- Disabled `lmformatenforcer` logging, which happens in the rare case when we're
  few-shot evaluating a model on NER and there are no JSON-valid tokens to generate.

Closes #197 