### PR TITLE
Feat/change summarisation dataset configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The default value of the languages are now all languages, rather than only Danish,
   Swedish and Norwegian.
+- Changed all summarisation datasets to use one few-shot example (some were set to 2),
+  and increased the maximum amount of generated tokens to 256 rather than the previous
+  128, since many of the gold standard summaries are around 200 tokens.
 
 ### Fixed
 - There was an error caused if an old version of the `openai` package was installed and

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -624,7 +624,7 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     languages=[DA],
     prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
     prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=128,
 )
 
@@ -638,7 +638,7 @@ MLSUM_CONFIG = DatasetConfig(
     "Zusammenfassungen.",
     prompt_template="Nachrichtenartikel: {text}\nZusammenfassung: {target_text}",
     num_few_shot_examples=1,
-    max_generated_tokens=128,
+    max_generated_tokens=256,
 )
 
 RRN_CONFIG = DatasetConfig(
@@ -649,8 +649,8 @@ RRN_CONFIG = DatasetConfig(
     languages=[IS],
     prompt_prefix="Eftirfarandi eru fréttagreinar með tilheyrandi samantektum.",
     prompt_template="Fréttagrein: {text}\nSamantekt: {target_text}",
-    num_few_shot_examples=2,
-    max_generated_tokens=128,
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
 )
 
 NO_SAMMENDRAG_CONFIG = DatasetConfig(
@@ -661,8 +661,8 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     languages=[NB, NN],
     prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
     prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
-    num_few_shot_examples=2,
-    max_generated_tokens=128,
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
 )
 
 WIKI_LINGUA_NL_CONFIG = DatasetConfig(
@@ -673,8 +673,8 @@ WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     languages=[NL],
     prompt_prefix="Hieronder volgen artikelen met bijbehorende samenvattingen.",
     prompt_template="Artikel: {text}\nSamenvatting: {target_text}",
-    num_few_shot_examples=2,
-    max_generated_tokens=128,
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
 )
 
 SWEDN_CONFIG = DatasetConfig(
@@ -686,7 +686,7 @@ SWEDN_CONFIG = DatasetConfig(
     prompt_prefix="Nedan följer artiklar med tillhörande sammanfattningar.",
     prompt_template="Artikel: {text}\nSammanfattning: {target_text}",
     num_few_shot_examples=1,
-    max_generated_tokens=128,
+    max_generated_tokens=256,
 )
 
 CNN_DAILYMAIL_CONFIG = DatasetConfig(
@@ -698,7 +698,7 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     prompt_prefix="The following are articles with accompanying summaries.",
     prompt_template="News article: {text}\nSummary: {target_text}",
     num_few_shot_examples=1,
-    max_generated_tokens=128,
+    max_generated_tokens=256,
 )
 
 # TODO: Faroese summarization


### PR DESCRIPTION
### Changed
- Changed all summarisation datasets to use one few-shot example (some were set to 2),
  and increased the maximum amount of generated tokens to 256 rather than the previous
  128, since many of the gold standard summaries are around 200 tokens.