### PR TITLE
Feat/201 add num iterations flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   default parameters are set during initialisation, and then any of these can be
   changed if needed when performing a concrete evaluation, without having to
   re-initialise the `Benchmarker`.
+- Added a `--num-iterations` flag (`num_iterations` in the Python CLI), which controls
+  the number of times each model should be evaluated, defaulting to the usual 10
+  iterations. This is only meant to be changed for power users, and if it is changed
+  then the resulting scores will not be included in the leaderboards.
 
 ### Changed
 - The default value of the languages are now all languages, rather than only Danish,

--- a/makefile
+++ b/makefile
@@ -126,6 +126,12 @@ test-cpu:
 		&& USE_CUDA=0 poetry run pytest | tee tests_with_cpu.log \
 		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
 
+test-fast:  # Run CPU tests without evaluations
+	@rm tests_with_cpu.log; \
+		date "+%H:%M:%S ⋅ Running fast tests with CPU..." \
+		&& USE_CUDA=0 TEST_EVALUATIONS=0 poetry run pytest | tee tests_with_cpu.log \
+		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
+
 update-coverage-badge:
 	@poetry run readme-cov
 	@rm .coverage*

--- a/makefile
+++ b/makefile
@@ -112,25 +112,25 @@ test-cuda-vllm:
 	@rm tests_with_cuda_and_vllm.log; \
 		date "+%H:%M:%S ⋅ Running tests with CUDA and vLLM..." \
 		&& USE_CUDA=1 USE_VLLM=1 poetry run pytest | tee tests_with_cuda_and_vllm.log \
-		&& date "+%H:%M:%S ⋅ Successfully tested with CUDA and vLLM!"
+		&& date "+%H:%M:%S ⋅ Finished testing with CUDA and vLLM!"
 
 test-cuda-no-vllm:
 	@rm tests_with_cuda_and_no_vllm.log; \
 		date "+%H:%M:%S ⋅ Running tests with CUDA and no vLLM..." \
 		&& USE_CUDA=1 USE_VLLM=0 poetry run pytest | tee tests_with_cuda_and_no_vllm.log \
-		&& date "+%H:%M:%S ⋅ Successfully tested with CUDA and no vLLM!"
+		&& date "+%H:%M:%S ⋅ Finished testing with CUDA and no vLLM!"
 
 test-cpu:
 	@rm tests_with_cpu.log; \
 		date "+%H:%M:%S ⋅ Running tests with CPU..." \
 		&& USE_CUDA=0 poetry run pytest | tee tests_with_cpu.log \
-		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
+		&& date "+%H:%M:%S ⋅ Finished testing with CPU!"
 
 test-fast:  # Run CPU tests without evaluations
 	@rm tests_with_cpu_fast.log; \
 		date "+%H:%M:%S ⋅ Running fast tests with CPU..." \
 		&& USE_CUDA=0 TEST_EVALUATIONS=0 poetry run pytest | tee tests_with_cpu_fast.log \
-		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
+		&& date "+%H:%M:%S ⋅ Finished fast testing with CPU!"
 
 update-coverage-badge:
 	@poetry run readme-cov

--- a/makefile
+++ b/makefile
@@ -127,9 +127,9 @@ test-cpu:
 		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
 
 test-fast:  # Run CPU tests without evaluations
-	@rm tests_with_cpu.log; \
+	@rm tests_with_cpu_fast.log; \
 		date "+%H:%M:%S ⋅ Running fast tests with CPU..." \
-		&& USE_CUDA=0 TEST_EVALUATIONS=0 poetry run pytest | tee tests_with_cpu.log \
+		&& USE_CUDA=0 TEST_EVALUATIONS=0 poetry run pytest | tee tests_with_cpu_fast.log \
 		&& date "+%H:%M:%S ⋅ Successfully tested with CPU!"
 
 update-coverage-badge:

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -37,6 +37,7 @@ def build_benchmark_config(
     clear_model_cache: bool,
     only_validation_split: bool,
     few_shot: bool,
+    num_iterations: int,
 ) -> BenchmarkConfig:
     """Create a benchmark configuration.
 
@@ -96,6 +97,8 @@ def build_benchmark_config(
             Whether to only use the validation split for the datasets.
         few_shot:
             Whether to use few-shot learning for the models.
+        num_iterations:
+            The number of iterations each model should be evaluated for.
 
     Returns:
         The benchmark configuration.
@@ -142,6 +145,7 @@ def build_benchmark_config(
         clear_model_cache=clear_model_cache,
         only_validation_split=only_validation_split,
         few_shot=few_shot,
+        num_iterations=num_iterations,
     )
 
 

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -149,7 +149,10 @@ class BenchmarkDataset(ABC):
         )
 
         # Set variable with number of iterations
-        num_iter = 2 if hasattr(sys, "_called_from_test") else 10
+        if hasattr(sys, "_called_from_test"):
+            num_iter = 2
+        else:
+            num_iter = self.benchmark_config.num_iterations
 
         if self.dataset_config.task != SPEED:
             train, val, tests = self._load_data(num_iter=num_iter, rng=rng)

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -52,6 +52,7 @@ class BenchmarkConfigParams(BaseModel):
     clear_model_cache: bool
     only_validation_split: bool
     few_shot: bool
+    num_iterations: int
 
 
 class BenchmarkResult(BaseModel):
@@ -157,6 +158,7 @@ class Benchmarker:
         clear_model_cache: bool = False,
         only_validation_split: bool = False,
         few_shot: bool = True,
+        num_iterations: int = 10,
     ) -> None:
         """Initialise the benchmarker.
 
@@ -231,6 +233,10 @@ class Benchmarker:
             few_shot:
                 Whether to only evaluate the model using few-shot evaluation. Only
                 relevant if the model is generative. Defaults to True.
+            num_iterations:
+                The number of times each model should be evaluated. This is only meant
+                to be used for power users, and scores will not be allowed on the
+                leaderboards if this is changed.
 
         Raises:
             ValueError:
@@ -263,6 +269,7 @@ class Benchmarker:
             clear_model_cache=clear_model_cache,
             only_validation_split=only_validation_split,
             few_shot=few_shot,
+            num_iterations=num_iterations,
         )
 
         self.benchmark_config = build_benchmark_config(
@@ -318,6 +325,7 @@ class Benchmarker:
         clear_model_cache: bool | None = None,
         only_validation_split: bool | None = None,
         few_shot: bool | None = None,
+        num_iterations: int | None = None,
     ) -> list[BenchmarkResult]:
         """Benchmarks models on datasets.
 
@@ -412,6 +420,11 @@ class Benchmarker:
                 Whether to only evaluate the model using few-shot evaluation. Only
                 relevant if the model is generative. Defaults to the value specified
                 when initialising the benchmarker.
+            num_iterations:
+                The number of times each model should be evaluated. This is only meant
+                to be used for power users, and scores will not be allowed on the
+                leaderboards if this is changed. Defaults to the value specified when
+                initialising the benchmarker.
 
         Returns:
             A list of benchmark results.
@@ -472,6 +485,8 @@ class Benchmarker:
             benchmark_config_params.only_validation_split = only_validation_split
         if few_shot is not None:
             benchmark_config_params.few_shot = few_shot
+        if num_iterations is not None:
+            benchmark_config_params.num_iterations = num_iterations
 
         benchmark_config = build_benchmark_config(
             **benchmark_config_params.model_dump()

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -203,6 +203,14 @@ from .tasks import get_all_tasks
     help="Whether to only evaluate the model using few-shot evaluation. Only relevant "
     "if the model is generative.",
 )
+@click.option(
+    "--num-iterations",
+    default=10,
+    show_default=True,
+    help="""The number of times each model should be evaluated. This is only meant to
+    be used for power users, and scores will not be allowed on the leaderboards if this
+    is changed.""",
+)
 def benchmark(
     model: tuple[str],
     dataset: tuple[str],
@@ -228,6 +236,7 @@ def benchmark(
     clear_model_cache: bool,
     only_validation_split: bool,
     few_shot: bool,
+    num_iterations: int,
 ) -> None:
     """Benchmark pretrained language models on language tasks."""
     # Set up language variables
@@ -265,6 +274,7 @@ def benchmark(
         clear_model_cache=clear_model_cache,
         only_validation_split=only_validation_split,
         few_shot=few_shot,
+        num_iterations=num_iterations,
     )
 
     # Perform the benchmark evaluation

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -147,6 +147,8 @@ class BenchmarkConfig:
         few_shot:
             Whether to only evaluate the model using few-shot evaluation. Only relevant
             if the model is generative.
+        num_iterations:
+            The number of iterations each model should be evaluated for.
     """
 
     model_languages: list[Language]
@@ -171,6 +173,7 @@ class BenchmarkConfig:
     clear_model_cache: bool
     only_validation_split: bool
     few_shot: bool
+    num_iterations: int
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def benchmark_config(
         clear_model_cache=False,
         only_validation_split=False,
         few_shot=True,
+        num_iterations=10,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def auth() -> Generator[str | bool, None, None]:
 @pytest.fixture(scope="session")
 def device() -> Generator[torch.device, None, None]:
     """Yields the device to use for the tests."""
-    device = torch.device("cuda" if os.getenv("USE_CUDA", False) else "cpu")
+    device = torch.device("cuda" if os.getenv("USE_CUDA", "0") == "1" else "cpu")
     yield device
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@
 from typing import Generator
 
 import pytest
-from click import ParamType
+from click import INT, ParamType
 from click.types import BOOL, STRING, Choice
 from scandeval.cli import benchmark
 
@@ -42,6 +42,7 @@ def test_cli_param_names(params):
         "clear_model_cache",
         "only_validation_split",
         "few_shot",
+        "num_iterations",
         "help",
     }
 
@@ -72,4 +73,5 @@ def test_cli_param_types(params):
     assert params["clear_model_cache"] == BOOL
     assert params["only_validation_split"] == BOOL
     assert params["few_shot"] == BOOL
+    assert params["num_iterations"] == INT
     assert params["help"] == BOOL

--- a/tests/test_named_entity_recognition.py
+++ b/tests/test_named_entity_recognition.py
@@ -1,5 +1,6 @@
 """Unit tests for the `named_entity_recognition` module."""
 
+import os
 from contextlib import nullcontext as does_not_raise
 from typing import Generator
 
@@ -55,6 +56,7 @@ def benchmark_dataset(
     )
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_encoder_benchmarking(benchmark_dataset, model_id):
     """Test that encoder models can be benchmarked on named entity recognition."""
     if benchmark_dataset.dataset_config.task.name in GENERATIVE_DATASET_TASKS:
@@ -65,6 +67,7 @@ def test_encoder_benchmarking(benchmark_dataset, model_id):
             benchmark_dataset.benchmark(model_id)
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_decoder_benchmarking(benchmark_dataset, generative_model_id):
     """Test that decoder models can be benchmarked on named entity recognition."""
     with does_not_raise():

--- a/tests/test_question_answering.py
+++ b/tests/test_question_answering.py
@@ -1,5 +1,6 @@
 """Unit tests for the `question_answering` module."""
 
+import os
 from contextlib import nullcontext as does_not_raise
 from typing import Generator
 
@@ -50,6 +51,7 @@ def benchmark_dataset(
     )
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_encoder_benchmarking(benchmark_dataset, model_id):
     """Test that encoder models can be benchmarked on question answering datasets."""
     if benchmark_dataset.dataset_config.task.name in GENERATIVE_DATASET_TASKS:
@@ -60,6 +62,7 @@ def test_encoder_benchmarking(benchmark_dataset, model_id):
             benchmark_dataset.benchmark(model_id)
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_decoder_benchmarking(benchmark_dataset, generative_model_id):
     """Test that decoder models can be benchmarked on question answering datasets."""
     with does_not_raise():

--- a/tests/test_sequence_classification.py
+++ b/tests/test_sequence_classification.py
@@ -1,5 +1,6 @@
 """Unit tests for the `sequence_classification` module."""
 
+import os
 from contextlib import nullcontext as does_not_raise
 from typing import Generator
 
@@ -136,6 +137,7 @@ def benchmark_dataset(
     )
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_encoder_benchmarking(benchmark_dataset, model_id):
     """Test that the encoder can be benchmarked on sequence classification datasets."""
     if benchmark_dataset.dataset_config.task.name in GENERATIVE_DATASET_TASKS:
@@ -146,6 +148,7 @@ def test_encoder_benchmarking(benchmark_dataset, model_id):
             benchmark_dataset.benchmark(model_id)
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_decoder_sequence_benchmarking(benchmark_dataset, generative_model_id):
     """Test that the decoder can be benchmarked on sequence classification datasets."""
     with does_not_raise():

--- a/tests/test_text_to_text.py
+++ b/tests/test_text_to_text.py
@@ -1,5 +1,6 @@
 """Unit tests for the `text_to_text` module."""
 
+import os
 from contextlib import nullcontext as does_not_raise
 from typing import Generator
 
@@ -45,6 +46,7 @@ def benchmark_dataset(
     yield TextToText(dataset_config=request.param, benchmark_config=benchmark_config)
 
 
+@pytest.mark.skipif(condition=os.getenv("TEST_EVALUATIONS") == "0", reason="Skipped")
 def test_decoder_benchmarking(benchmark_dataset, generative_model_id):
     """Test that decoder models can be benchmarked on text-to-text tasks."""
     with does_not_raise():


### PR DESCRIPTION
### Added
- Added a `--num-iterations` flag (`num_iterations` in the Python CLI), which controls
  the number of times each model should be evaluated, defaulting to the usual 10
  iterations. This is only meant to be changed for power users, and if it is changed
  then the resulting scores will not be included in the leaderboards.

This closes #201 