### PR TITLE
feat: Add danish-citizen-tests dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   default parameters are set during initialisation, and then any of these can be
   changed if needed when performing a concrete evaluation, without having to
   re-initialise the `Benchmarker`.
-- Added the Danish knowledge dataset `danske-talemaader`, which is a multiple choice
-  dataset, checking whether the language models know the meaning of Danish idioms. This
-  complements MMLU-da, as this datasets checks knowledge about the Danish language, and
-  MMLU-da checks knowledge about the world.
+- Added the Danish knowledge datasets `danske-talemaader` and `danish-citizen-tests`.
+  Both are multiple choice datasets, where the first one tests knowledge about Danish
+  idioms, and the second one tests knowledge about the Danish society. These replace
+  the machine translated MMLU-da dataset.
 - Added a `--num-iterations` flag (`num_iterations` in the Python CLI), which controls
   the number of times each model should be evaluated, defaulting to the usual 10
   iterations. This is only meant to be changed for power users, and if it is changed

--- a/src/scandeval/__init__.py
+++ b/src/scandeval/__init__.py
@@ -24,11 +24,7 @@ load_dotenv()
 
 
 # Set up logging
-fmt = (
-    colored("%(asctime)s - %(name)s", "light_blue")
-    + " ⋅ "
-    + colored("%(message)s", "green")
-)
+fmt = colored("%(asctime)s", "light_blue") + " ⋅ " + colored("%(message)s", "green")
 logging.basicConfig(
     level=logging.CRITICAL if hasattr(sys, "_called_from_test") else logging.INFO,
     format=fmt,

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -747,11 +747,10 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     max_generated_tokens=3,
 )
 
-MMLU_DA_CONFIG = DatasetConfig(
-    name="mmlu-da",
-    pretty_name="the truncated version of the Danish knowledge dataset MMLU-da, "
-    "translated from the English MMLU dataset",
-    huggingface_id="ScandEval/mmlu-da-mini",
+DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
+    name="danish-citizen-tests",
+    pretty_name="the Danish knowledge dataset Danish Citizen Tests",
+    huggingface_id="ScandEval/danish-citizen-tests",
     task=KNOW,
     languages=[DA],
     prompt_prefix="Følgende er multiple choice spørgsmål (med svar).",

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -222,9 +222,12 @@ class SequenceClassification(BenchmarkDataset):
         # examples
         while len(few_shot_examples) < num_few_shots:
             label = next(labels)
-            example = shuffled_train.filter(
+            possible_examples = shuffled_train.filter(
                 lambda x: x["label"].lower() == label.lower()
-            ).select(range(1))[0]
+            )
+            if len(possible_examples) == 0:
+                continue
+            example = possible_examples.select(range(1))[0]
             few_shot_examples.append(example)
             shuffled_train = shuffled_train.filter(
                 lambda x: x["text"] != example["text"]

--- a/src/scripts/create_danish_citizen_tests.py
+++ b/src/scripts/create_danish_citizen_tests.py
@@ -1,0 +1,96 @@
+"""Create the DanishCitizenTests-mini dataset and upload it to the HF Hub."""
+
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+from sklearn.model_selection import train_test_split
+
+
+def main() -> None:
+    """Create the DanishCitizenTests-mini dataset and upload it to the HF Hub."""
+    # Define the base download URL
+    repo_id = "alexandrainst/danish-citizen-tests"
+
+    # Download the dataset
+    dataset = load_dataset(path=repo_id, split="train")
+    assert isinstance(dataset, Dataset)
+
+    # Convert the dataset to a dataframe
+    df = dataset.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+
+    # Rename the columns
+    df.rename(columns=dict(answer="label", question="instruction"), inplace=True)
+
+    # Make a `text` column with all the options in it
+    texts = list()
+    for _, row in df.iterrows():
+        text = (
+            row.instruction.replace("\n", " ").strip() + "\n"
+            "Svarmuligheder:\n"
+            "a. " + row.option_a.replace("\n", " ").strip() + "\n"
+            "b. " + row.option_b.replace("\n", " ").strip()
+        )
+        if row.option_c is not None:
+            text += "\nc. " + row.option_c.replace("\n", " ").strip()
+        texts.append(text)
+    df["text"] = texts
+
+    # Make the `label` column case-consistent with the `text` column
+    df.label = df.label.str.lower()
+
+    df = df[["text", "label", "test_type"]]
+
+    # Remove duplicates
+    df.drop_duplicates(inplace=True)
+    df.reset_index(drop=True, inplace=True)
+
+    # Create validation split
+    val_size = 128
+    traintest_arr, val_arr = train_test_split(
+        df, test_size=val_size, random_state=4242, stratify=df.test_type
+    )
+    traintest_df = pd.DataFrame(traintest_arr, columns=df.columns)
+    val_df = pd.DataFrame(val_arr, columns=df.columns)
+
+    # Create test split
+    test_size = 512
+    train_arr, test_arr = train_test_split(
+        traintest_df,
+        test_size=test_size,
+        random_state=4242,
+        stratify=traintest_df.test_type,
+    )
+    train_df = pd.DataFrame(train_arr, columns=df.columns)
+    test_df = pd.DataFrame(test_arr, columns=df.columns)
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Create dataset ID
+    dataset_id = "ScandEval/danish-citizen-tests"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api = HfApi()
+        api.delete_repo(dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(dataset_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from scandeval.config import (
     ModelConfig,
     Task,
 )
-from scandeval.dataset_configs import MMLU_DA_CONFIG, get_all_dataset_configs
+from scandeval.dataset_configs import MMLU_CONFIG, get_all_dataset_configs
 from scandeval.enums import Framework, ModelType
 from scandeval.tasks import SPEED
 
@@ -147,4 +147,4 @@ def model_config(language) -> Generator[ModelConfig, None, None]:
 @pytest.fixture(scope="session")
 def generative_dataset_config() -> Generator[DatasetConfig, None, None]:
     """Yields a generative dataset configuration used in tests."""
-    yield MMLU_DA_CONFIG
+    yield MMLU_CONFIG

--- a/tests/test_sequence_classification.py
+++ b/tests/test_sequence_classification.py
@@ -8,6 +8,7 @@ import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import (
     ANGRY_TWEETS_CONFIG,
+    DANISH_CITIZEN_TESTS_CONFIG,
     DANSKE_TALEMAADER_CONFIG,
     DUTCH_SOCIAL_CONFIG,
     HELLASWAG_CONFIG,
@@ -18,7 +19,6 @@ from scandeval.dataset_configs import (
     HELLASWAG_NO_CONFIG,
     HELLASWAG_SV_CONFIG,
     MMLU_CONFIG,
-    MMLU_DA_CONFIG,
     MMLU_DE_CONFIG,
     MMLU_IS_CONFIG,
     MMLU_NL_CONFIG,
@@ -62,7 +62,7 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
         SCALA_NL_CONFIG,
         SCALA_EN_CONFIG,
         DANSKE_TALEMAADER_CONFIG,
-        MMLU_DA_CONFIG,
+        DANISH_CITIZEN_TESTS_CONFIG,
         MMLU_SV_CONFIG,
         MMLU_NO_CONFIG,
         MMLU_IS_CONFIG,
@@ -94,7 +94,7 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
         "scala-nl",
         "scala-en",
         "danske-talemaader",
-        "mmlu-da",
+        "danish-citizen-tests",
         "mmlu-sv",
         "mmlu-no",
         "mmlu-is",


### PR DESCRIPTION
### Added
- Added the Danish knowledge datasets `danske-talemaader` and `danish-citizen-tests`.
  Both are multiple choice datasets, where the first one tests knowledge about Danish
  idioms, and the second one tests knowledge about the Danish society. These replace
  the machine translated MMLU-da dataset.

This closes #227 