### PR TITLE
Feat/faster summ metric calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Changed
+- Computation of the BERTScore metric for summarisation tasks are now using the device
+  stated in the benchmark config, making the metric computation significantly faster if
+  a GPU is being used. This defaults to processing 32 samples at a time, which is
+  reduced if OOM errors occur. If OOM errors occur with a batch size of 1 then the
+  scores are computed on CPU, as before.
+
+
 ## [v11.0.0] - 2024-02-16
 ### Added
 - Added arguments to `Benchmarker.benchmark` (or simply `Benchmarker.__call_`),

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -127,6 +127,25 @@ def generate(
                     dataset_config=dataset_config,
                     cache=cache,
                 )
+                logger.debug(f"Test scores for iteration {idx}: {test_scores}")
+                scores["test"].append(test_scores)
+
+                if benchmark_config.evaluate_train:
+                    train_scores = generate_single_iteration(
+                        prepared_dataset=prepared_train,
+                        model=model,
+                        tokenizer=tokenizer,
+                        data_collator=data_collator,
+                        compute_metrics=compute_metrics,
+                        extract_labels_fn=extract_labels_fn,
+                        benchmark_config=benchmark_config,
+                        dataset_config=dataset_config,
+                        cache=cache,
+                    )
+                    logger.debug(f"Train scores for iteration {idx}: {train_scores}")
+                    scores["train"].append(train_scores)
+
+                clear_memory()
                 break
             except Exception as e:
                 oom_error = [
@@ -143,26 +162,6 @@ def generate(
                     raise InvalidBenchmark(
                         "GPU out of memory, even with a batch size of 1!"
                     )
-
-        logger.debug(f"Test scores for iteration {idx}: {test_scores}")
-        scores["test"].append(test_scores)
-        clear_memory()
-
-        if benchmark_config.evaluate_train:
-            train_scores = generate_single_iteration(
-                prepared_dataset=prepared_train,
-                model=model,
-                tokenizer=tokenizer,
-                data_collator=data_collator,
-                compute_metrics=compute_metrics,
-                extract_labels_fn=extract_labels_fn,
-                benchmark_config=benchmark_config,
-                dataset_config=dataset_config,
-                cache=cache,
-            )
-            logger.debug(f"Train scores for iteration {idx}: {train_scores}")
-            scores["train"].append(train_scores)
-            clear_memory()
 
     cache.remove()
     return scores

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -120,7 +120,7 @@ SUMM = Task(
             huggingface_id="bertscore",
             results_key="f1",
             compute_kwargs=dict(
-                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=8
+                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=1
             ),
         ),
         MetricConfig(

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -119,7 +119,9 @@ SUMM = Task(
             pretty_name="BERTScore",
             huggingface_id="bertscore",
             results_key="f1",
-            compute_kwargs=dict(model_type="microsoft/mdeberta-v3-base", device="cpu"),
+            compute_kwargs=dict(
+                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=8
+            ),
         ),
         MetricConfig(
             name="rouge_l",

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -120,7 +120,7 @@ SUMM = Task(
             huggingface_id="bertscore",
             results_key="f1",
             compute_kwargs=dict(
-                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=1
+                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=32
             ),
         ),
         MetricConfig(

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -120,7 +120,7 @@ SUMM = Task(
             huggingface_id="bertscore",
             results_key="f1",
             compute_kwargs=dict(
-                model_type="microsoft/mdeberta-v3-base", device="cuda", batch_size=32
+                model_type="microsoft/mdeberta-v3-base", device="auto", batch_size=32
             ),
         ),
         MetricConfig(

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -125,7 +125,6 @@ class TextToText(BenchmarkDataset):
                         "CUDA out of memory",
                         "CUDA error",
                         "MPS backend out of memory",
-                        "Too many parallel completions requested.",  # OpenAI specific
                     ]
                     if not any(error in str(e) for error in oom_error):
                         raise InvalidBenchmark(str(e))

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -111,7 +111,7 @@ class TextToText(BenchmarkDataset):
             # with HiddenPrints():
 
             if cfg.name == "bertscore":
-                cfg.compute_kwargs["device"] = self.benchmark_config.device
+                cfg.compute_kwargs["device"] = self.benchmark_config.device.type
 
             breakpoint()
             score_dict: dict[str, float] | None = metric.compute(

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -13,7 +13,7 @@ from transformers.utils import ModelOutput
 from .benchmark_dataset import BenchmarkDataset, Labels, Predictions
 from .generation import extract_raw_predictions
 from .protocols import GenerativeModel, Tokenizer
-from .utils import HiddenPrints, raise_if_model_output_contains_nan_values
+from .utils import raise_if_model_output_contains_nan_values
 
 logger = logging.getLogger(__package__)
 
@@ -112,10 +112,14 @@ class TextToText(BenchmarkDataset):
             # if cfg.name == "bertscore":
             #     cfg.compute_kwargs["device"] = self.benchmark_config.device.type
 
-            with HiddenPrints():
+            # with HiddenPrints():
+            try:
                 score_dict: dict[str, float] | None = metric.compute(
                     predictions=predictions, references=labels, **cfg.compute_kwargs
                 )
+            except Exception:
+                breakpoint()
+                pass
 
             # The metric returns None if we are running on multi-GPU and the current
             # process is not the main process

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -13,7 +13,7 @@ from transformers.utils import ModelOutput
 from .benchmark_dataset import BenchmarkDataset, Labels, Predictions
 from .generation import extract_raw_predictions
 from .protocols import GenerativeModel, Tokenizer
-from .utils import HiddenPrints, raise_if_model_output_contains_nan_values
+from .utils import raise_if_model_output_contains_nan_values
 
 logger = logging.getLogger(__package__)
 
@@ -108,10 +108,15 @@ class TextToText(BenchmarkDataset):
         results: dict[str, float] = dict()
         for cfg in self.dataset_config.task.metrics:
             metric = self._metrics[cfg.name]
-            with HiddenPrints():
-                score_dict: dict[str, float] | None = metric.compute(
-                    predictions=predictions, references=labels, **cfg.compute_kwargs
-                )
+            # with HiddenPrints():
+
+            if cfg.name == "bertscore":
+                cfg.compute_kwargs["device"] = self.benchmark_config.device
+
+            breakpoint()
+            score_dict: dict[str, float] | None = metric.compute(
+                predictions=predictions, references=labels, **cfg.compute_kwargs
+            )
 
             # The metric returns None if we are running on multi-GPU and the current
             # process is not the main process

--- a/src/scandeval/text_to_text.py
+++ b/src/scandeval/text_to_text.py
@@ -13,7 +13,7 @@ from transformers.utils import ModelOutput
 from .benchmark_dataset import BenchmarkDataset, Labels, Predictions
 from .generation import extract_raw_predictions
 from .protocols import GenerativeModel, Tokenizer
-from .utils import raise_if_model_output_contains_nan_values
+from .utils import HiddenPrints, raise_if_model_output_contains_nan_values
 
 logger = logging.getLogger(__package__)
 
@@ -108,15 +108,14 @@ class TextToText(BenchmarkDataset):
         results: dict[str, float] = dict()
         for cfg in self.dataset_config.task.metrics:
             metric = self._metrics[cfg.name]
-            # with HiddenPrints():
 
-            if cfg.name == "bertscore":
-                cfg.compute_kwargs["device"] = self.benchmark_config.device.type
+            # if cfg.name == "bertscore":
+            #     cfg.compute_kwargs["device"] = self.benchmark_config.device.type
 
-            breakpoint()
-            score_dict: dict[str, float] | None = metric.compute(
-                predictions=predictions, references=labels, **cfg.compute_kwargs
-            )
+            with HiddenPrints():
+                score_dict: dict[str, float] | None = metric.compute(
+                    predictions=predictions, references=labels, **cfg.compute_kwargs
+                )
 
             # The metric returns None if we are running on multi-GPU and the current
             # process is not the main process

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -106,6 +106,7 @@ class VLLMModel:
                 trust_remote_code=trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
+                eager=True,
             )
             self._model._run_engine = MethodType(
                 _run_engine_with_fixed_progress_bars, self._model

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -106,7 +106,7 @@ class VLLMModel:
                 trust_remote_code=trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
-                eager=True,
+                enforce_eager=True,
             )
             self._model._run_engine = MethodType(
                 _run_engine_with_fixed_progress_bars, self._model

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -106,7 +106,6 @@ class VLLMModel:
                 trust_remote_code=trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
-                enforce_eager=True,
             )
             self._model._run_engine = MethodType(
                 _run_engine_with_fixed_progress_bars, self._model


### PR DESCRIPTION
### Changed
- Computation of the BERTScore metric for summarisation tasks are now using the device
  stated in the benchmark config, making the metric computation significantly faster if
  a GPU is being used. This defaults to processing 32 samples at a time, which is
  reduced if OOM errors occur. If OOM errors occur with a batch size of 1 then the
  scores are computed on CPU, as before.