### PR TITLE
tests: Add structured generation tests, don't use it when evaluating NER

### DIFF
--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -157,7 +157,7 @@ def build_benchmark_config(
 
     # Set variable with number of iterations
     if hasattr(sys, "_called_from_test"):
-        num_iterations = 2
+        num_iterations = 1
 
     return BenchmarkConfig(
         model_languages=model_languages,

--- a/src/scandeval/finetuning.py
+++ b/src/scandeval/finetuning.py
@@ -418,7 +418,7 @@ def get_training_args(
             eval_steps=30,
             logging_steps=30,
             save_steps=30,
-            max_steps=2 if hasattr(sys, "_called_from_test") else 10_000,
+            max_steps=1 if hasattr(sys, "_called_from_test") else 10_000,
             use_cpu=benchmark_config.device == torch.device("cpu"),
             report_to=[],
             save_total_limit=1,

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -460,9 +460,14 @@ def generate_batch(
         inputs = batch["input_ids"].to(model.device)
         stopping_criteria.clear()
 
-        if dataset_config.task == NER and isinstance(
-            tokenizer, PreTrainedTokenizerBase
-        ):
+        use_structured_generation = (
+            dataset_config == NER
+            and isinstance(tokenizer, PreTrainedTokenizerBase)
+            and not hasattr(sys, "_called_from_test")
+        )
+
+        if use_structured_generation:
+            assert isinstance(tokenizer, PreTrainedTokenizerBase)
             prefix_allowed_tokens_fn = get_ner_prefix_allowed_tokens_fn(
                 ner_tag_names=list(dataset_config.prompt_label_mapping.values()),
                 tokenizer=tokenizer,

--- a/tests/test_named_entity_recognition.py
+++ b/tests/test_named_entity_recognition.py
@@ -8,6 +8,7 @@ import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import get_all_dataset_configs
 from scandeval.exceptions import InvalidBenchmark
+from scandeval.languages import DA
 from scandeval.named_entity_recognition import NamedEntityRecognition
 from scandeval.tasks import NER
 from scandeval.utils import GENERATIVE_DATASET_TASKS
@@ -20,7 +21,8 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
         for dataset_config in get_all_dataset_configs().values()
         if dataset_config.task == NER
         and (
-            os.getenv("TEST_ALL_DATASETS", "0") == "1" or not dataset_config.unofficial
+            os.getenv("TEST_ALL_DATASETS", "0") == "1"
+            or (not dataset_config.unofficial and dataset_config.languages == [DA])
         )
     ],
     ids=lambda dataset_config: dataset_config.name,

--- a/tests/test_question_answering.py
+++ b/tests/test_question_answering.py
@@ -8,6 +8,7 @@ import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import get_all_dataset_configs
 from scandeval.exceptions import InvalidBenchmark
+from scandeval.languages import DA
 from scandeval.question_answering import QuestionAnswering, prepare_train_examples
 from scandeval.tasks import QA
 from scandeval.utils import GENERATIVE_DATASET_TASKS
@@ -21,7 +22,8 @@ from transformers import AutoTokenizer
         for dataset_config in get_all_dataset_configs().values()
         if dataset_config.task == QA
         and (
-            os.getenv("TEST_ALL_DATASETS", "0") == "1" or not dataset_config.unofficial
+            os.getenv("TEST_ALL_DATASETS", "0") == "1"
+            or (not dataset_config.unofficial and dataset_config.languages == [DA])
         )
     ],
     ids=lambda dataset_config: dataset_config.name,

--- a/tests/test_sequence_classification.py
+++ b/tests/test_sequence_classification.py
@@ -8,6 +8,7 @@ import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import get_all_dataset_configs
 from scandeval.exceptions import InvalidBenchmark
+from scandeval.languages import DA
 from scandeval.sequence_classification import SequenceClassification
 from scandeval.tasks import COMMON_SENSE, KNOW, SENT
 from scandeval.utils import GENERATIVE_DATASET_TASKS
@@ -20,7 +21,8 @@ from scandeval.utils import GENERATIVE_DATASET_TASKS
         for dataset_config in get_all_dataset_configs().values()
         if dataset_config.task in [SENT, KNOW, COMMON_SENSE]
         and (
-            os.getenv("TEST_ALL_DATASETS", "0") == "1" or not dataset_config.unofficial
+            os.getenv("TEST_ALL_DATASETS", "0") == "1"
+            or (not dataset_config.unofficial and dataset_config.languages == [DA])
         )
     ],
     ids=lambda dataset_config: dataset_config.name,

--- a/tests/test_structured_generation_utils.py
+++ b/tests/test_structured_generation_utils.py
@@ -1,0 +1,76 @@
+"""Unit tests for the `structured_generation_utils` module."""
+
+import json
+from typing import Callable, Generator
+
+import pytest
+import torch
+from scandeval.generation import StopWordCriteria
+from scandeval.structured_generation_utils import get_ner_prefix_allowed_tokens_fn
+from scandeval.utils import create_model_cache_dir
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GenerationConfig,
+    PreTrainedModel,
+    PreTrainedTokenizerBase,
+    StoppingCriteriaList,
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer(generative_model_id) -> Generator[PreTrainedTokenizerBase, None, None]:
+    """A tokenizer for a generative model."""
+    yield AutoTokenizer.from_pretrained(generative_model_id)
+
+
+@pytest.fixture(scope="module")
+def model(
+    generative_model_id, benchmark_config
+) -> Generator[PreTrainedModel, None, None]:
+    """A generative model."""
+    model_cache_dir = create_model_cache_dir(
+        cache_dir=benchmark_config.cache_dir, model_id=generative_model_id
+    )
+    yield AutoModelForCausalLM.from_pretrained(
+        generative_model_id, cache_dir=model_cache_dir, torch_dtype=None
+    )
+
+
+@pytest.fixture(scope="module")
+def ner_prefix_allowed_tokens_fn(
+    tokenizer,
+) -> Generator[Callable[[int, torch.Tensor], list[int]], None, None]:
+    """A prefix_allowed_tokens_fn for named entity recognition."""
+    yield get_ner_prefix_allowed_tokens_fn(
+        ner_tag_names=["person", "location"], tokenizer=tokenizer
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="input_str",
+    argvalues=[
+        "John works at Novo Nordisk.",
+        "Peter lives in Copenhagen.",
+        "He loves to surf.",
+    ],
+    ids=["person-no-location", "person-location", "no-person-no-location"],
+)
+def test_prefix_allowed_tokens_fn(
+    tokenizer, model, ner_prefix_allowed_tokens_fn, input_str
+):
+    """Test the `prefix_allowed_tokens_fn` for named entity recognition."""
+    input_ids = tokenizer(input_str, return_tensors="pt").input_ids
+    stopping_criteria = StopWordCriteria(
+        stop_word_id_lists=[tokenizer.encode("}"), [tokenizer.eos_token_id]]
+    )
+    completion = model.generate(
+        input_ids,
+        generation_config=GenerationConfig(do_sample=False, max_new_tokens=32),
+        stopping_criteria=StoppingCriteriaList([stopping_criteria]),
+        prefix_allowed_tokens_fn=ner_prefix_allowed_tokens_fn,
+    )[0][input_ids.shape[-1] :]
+    completion_str = tokenizer.decode(completion, skip_special_tokens=True)
+    parsed_output = json.loads(completion_str)
+    assert isinstance(parsed_output, dict)
+    assert set(list(parsed_output.keys())) == {"person", "location"}

--- a/tests/test_text_to_text.py
+++ b/tests/test_text_to_text.py
@@ -7,6 +7,7 @@ from typing import Generator
 import pytest
 from scandeval.benchmark_dataset import BenchmarkDataset
 from scandeval.dataset_configs import get_all_dataset_configs
+from scandeval.languages import DA
 from scandeval.tasks import SUMM
 from scandeval.text_to_text import TextToText
 
@@ -18,7 +19,8 @@ from scandeval.text_to_text import TextToText
         for dataset_config in get_all_dataset_configs().values()
         if dataset_config.task == SUMM
         and (
-            os.getenv("TEST_ALL_DATASETS", "0") == "1" or not dataset_config.unofficial
+            os.getenv("TEST_ALL_DATASETS", "0") == "1"
+            or (not dataset_config.unofficial and dataset_config.languages == [DA])
         )
     ],
     ids=lambda dataset_config: dataset_config.name,


### PR DESCRIPTION
To reduce unit testing time, we don't use structured generation when evaluating NER, but instead test it once separately.