### PR TITLE
fix: Setting of add_prefix_space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Setting `add_prefix_space=False` caused an error during the loading of some
+  tokenizers. To fix this, we only supply the `add_prefix_space` keyword argument
+  during the loading of the tokenizer if it is True.
+
+
 ## [v12.3.1] - 2024-03-13
 ### Fixed
 - An issue with Pydantic typing, causing initialisation of `Benchmarker` to throw an


### PR DESCRIPTION
### Fixed
- Setting `add_prefix_space=False` caused an error during the loading of some
  tokenizers. To fix this, we only supply the `add_prefix_space` keyword argument
  during the loading of the tokenizer if it is True.