### PR TITLE
Bandaid fixes to support azure

### DIFF
--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -41,6 +41,7 @@ def build_benchmark_config(
     prefer_azure: bool,
     azure_openai_api_key: str | None,
     azure_openai_endpoint: str | None,
+    azure_openai_api_version: str | None,
     force: bool,
     verbose: bool,
     trust_remote_code: bool,
@@ -101,6 +102,8 @@ def build_benchmark_config(
             The Azure OpenAI API key to use for running the models.
         azure_openai_endpoint:
             The Azure OpenAI endpoint to use for running the models.
+        azure_openai_api_version:
+            The Azure OpenAI api version to use for running the models.
         force:
             Whether to force the benchmark to run even if the results are already
             cached.
@@ -150,11 +153,13 @@ def build_benchmark_config(
         azure_openai_api_key = os.getenv("AZURE_OPENAI_API_KEY")
     if azure_openai_endpoint is None:
         azure_openai_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    if azure_openai_api_version is None:
+        azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
 
     # Ensure that we are not using both OpenAI and Azure OpenAI API keys
     if all(
         value is not None
-        for value in (openai_api_key, azure_openai_api_key, azure_openai_endpoint)
+        for value in (openai_api_key, azure_openai_api_key, azure_openai_endpoint, azure_openai_api_version)
     ):
         if prefer_azure:
             logger.info(
@@ -218,6 +223,7 @@ def build_benchmark_config(
         openai_api_key=openai_api_key,
         azure_openai_api_key=azure_openai_api_key,
         azure_openai_endpoint=azure_openai_endpoint,
+        azure_openai_api_version=azure_openai_api_version,
         force=force,
         progress_bar=progress_bar,
         save_results=save_results,

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -51,6 +51,7 @@ class BenchmarkConfigParams(BaseModel):
     prefer_azure: bool
     azure_openai_api_key: str | None
     azure_openai_endpoint: str | None
+    azure_openai_api_version: str | None
     force: bool
     verbose: bool
     trust_remote_code: bool
@@ -161,6 +162,7 @@ class Benchmarker:
         prefer_azure: bool = False,
         azure_openai_api_key: str | None = None,
         azure_openai_endpoint: str | None = None,
+        azure_openai_api_version: str |None = None,
         force: bool = False,
         verbose: bool = False,
         trust_remote_code: bool = False,
@@ -235,6 +237,10 @@ class Benchmarker:
                 The Azure OpenAI endpoint to use for authentication. If None, then this
                 will be loaded from the environment variable `AZURE_OPENAI_ENDPOINT`.
                 Defaults to None.
+            azure_openai_api_version:
+                The Azure OpenAI API version to use for authentication. If None, then this
+                will be loaded from the environment variable `AZURE_OPENAI_API_VERSION`.
+                Defaults to None.
             force:
                 Whether to force evaluations of models, even if they have been
                 benchmarked already. Defaults to False.
@@ -292,6 +298,7 @@ class Benchmarker:
             prefer_azure=prefer_azure,
             azure_openai_api_key=azure_openai_api_key,
             azure_openai_endpoint=azure_openai_endpoint,
+            azure_openai_api_version=azure_openai_api_version,
             force=force,
             verbose=verbose,
             trust_remote_code=trust_remote_code,
@@ -350,6 +357,7 @@ class Benchmarker:
         openai_api_key: str | None = None,
         azure_openai_api_key: str | None = None,
         azure_openai_endpoint: str | None = None,
+        azure_openai_api_version: str |None = None,
         force: bool | None = None,
         verbose: bool | None = None,
         trust_remote_code: bool | None = None,
@@ -434,6 +442,10 @@ class Benchmarker:
                 The Azure OpenAI endpoint to use for authentication. If None, then this
                 will be loaded from the environment variable `AZURE_OPENAI_ENDPOINT`.
                 Defaults to the value specified when initialising the benchmarker.
+            azure_openai_api_version:
+                The api version for the Azure OpenAI API, e.g. "2023-12-01-preview". If
+                None then the environment varaible `AZURE_OPENAI_API_VERSION` will be used.
+                Defaults to the value specified when initialising the benchmarker.
             force:
                 Whether to force evaluations of models, even if they have been
                 benchmarked already. Defaults to the value specified when initialising
@@ -514,6 +526,8 @@ class Benchmarker:
             benchmark_config_params.azure_openai_api_key = azure_openai_api_key
         if azure_openai_endpoint is not None:
             benchmark_config_params.azure_openai_endpoint = azure_openai_endpoint
+        if azure_openai_api_version is not None:
+            benchmark_config_params.azure_openai_api_version = azure_openai_api_version
         if force is not None:
             benchmark_config_params.force = force
         if verbose is not None:

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -167,6 +167,14 @@ from .tasks import get_all_tasks
     variable `AZURE_OPENAI_ENDPOINT` will be used.""",
 )
 @click.option(
+    "--azure-openai-api-version",
+    type=str,
+    default=None,
+    show_default=True,
+    help="""The api version for the Azure OpenAI API, e.g. "2023-12-01-preview". If
+            None then the environment varaible `AZURE_OPENAI_API_VERSION` will be used.""",
+)
+@click.option(
     "--force/--no-force",
     "-f",
     default=False,
@@ -261,6 +269,7 @@ def benchmark(
     prefer_azure: bool,
     azure_openai_api_key: str | None,
     azure_openai_endpoint: str | None,
+    azure_openai_api_version: str |None,
     force: bool,
     verbose: bool,
     framework: str | None,
@@ -303,6 +312,7 @@ def benchmark(
         prefer_azure=prefer_azure,
         azure_openai_api_key=azure_openai_api_key,
         azure_openai_endpoint=azure_openai_endpoint,
+        azure_openai_api_version=azure_openai_api_version,
         force=force,
         cache_dir=cache_dir,
         framework=framework,

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -129,6 +129,9 @@ class BenchmarkConfig:
         azure_openai_endpoint:
             The endpoint for the Azure OpenAI API. If None then Azure OpenAI models will
             not be benchmarked.
+        azure_openai_api_version:
+            The api version for the Azure OpenAI API, e.g. "2023-12-01-preview". If
+            None then Azure OpenAI models will not be benchmarked.
         force:
             Whether to force the benchmark to run even if the results are already
             cached.
@@ -173,6 +176,7 @@ class BenchmarkConfig:
     openai_api_key: str | None
     azure_openai_api_key: str | None
     azure_openai_endpoint: str | None
+    azure_openai_api_version: str | None
     force: bool
     progress_bar: bool
     save_results: bool

--- a/src/scandeval/model_setups/openai.py
+++ b/src/scandeval/model_setups/openai.py
@@ -104,6 +104,11 @@ class OpenAIModelSetup:
         if importlib.util.find_spec("openai") is None:
             return dict(missing_extra="openai")
 
+        if self.benchmark_config.azure_openai_endpoint:
+            # The model ID for the Azure OpenAI API is the deployment name and therefore different
+            # from the model ID used in the OpenAI API. We'll just assume that the model exists.
+            return True
+
         all_models: list[openai.models.Model] = list()
         try:
             all_models = list(openai.models.list())
@@ -193,7 +198,12 @@ class OpenAIModelSetup:
         hf_model_config.pad_token_id = hf_model_config.vocab_size - 1
 
         # Check if the vocab size is correct, and if not then correct it
-        tok = tiktoken.encoding_for_model(model_name=model_config.model_id)
+        try:
+            tok = tiktoken.encoding_for_model(model_name=model_config.model_id)
+        except KeyError:
+            # For Azure, the model_id is the deployment name. I do not know how to dynamically
+            # get the currently deployed model so assuming Azure only supports the latest models.
+            tok = tiktoken.get_encoding("cl100k_base")
         for idx in range(hf_model_config.vocab_size - 1, 0, -1):
             try:
                 tok.decode([idx])


### PR DESCRIPTION
This PR adds a number of changes to support Azure's OpenAI service. Some noteworthy changes:

- add `azure_openai_api_version` argument, which is a required for API calls
- add corresponding environment variable
- naively assumes that Azure models only use cl100k_base tokenizer (they only support a handful of models like 3.5 and 4, not the older ones). The reason for this is that `model_config.model_id` must be the `deployment name` that was chosen when creating the endpoint. This can be arbitrary and will likely not be a valid model identifier. I do not know if/how you can get the currently deployed model from the client but perhaps someone else knows a way. That would make life easier.

Some stylistic issues may need to be changed and perhaps I missed some places where to add `azure_openai_api_version` (there's a lot of repetition of arguments so I hope I got them all).

With these changes I am currently running the benchmarks. Example command:

```shell
scandeval -l nl -m <deployment-name> --azure-openai-api-key <apik-key> --azure-openai-endpoint <https-endpoint> --azure-openai-api-version <api-version> --prefer-azure
```