### PR TITLE
Feat/revert vllm batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   happens when the prompt is caught by the content filter, then we simply return a
   blank string instead.
 
+### Changed
+- Updated `outlines` dependency to v0.0.37, which can now correctly deal with a larger
+  batch size when integrated with vLLM. This results in faster NER evaluation.
+
 
 ## [v12.3.2] - 2024-03-19
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3079,13 +3079,13 @@ testing = ["flax", "pytest", "pytest-xdist"]
 
 [[package]]
 name = "outlines"
-version = "0.0.36"
+version = "0.0.37"
 description = "Probabilistic Generative Model Programming"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "outlines-0.0.36-py3-none-any.whl", hash = "sha256:afa02ca5c449c47731fa06af66d13c2f5ee8b30f8b82b4db90e08215d6f111d1"},
-    {file = "outlines-0.0.36.tar.gz", hash = "sha256:3cffb43143548cd78c6061990feb461cffd5479999391b8390471ea839c2d46e"},
+    {file = "outlines-0.0.37-py3-none-any.whl", hash = "sha256:795ef2b3bcf58f6ddb44012f66d943385a7a1ba5efea205bc36745f82e7f597f"},
+    {file = "outlines-0.0.37.tar.gz", hash = "sha256:0d2708587c98822469c40994308590929afebeaba36611f8db970752fd283c7d"},
 ]
 
 [package.dependencies]
@@ -5751,10 +5751,10 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 all = ["ai2-olmo", "bert-score", "bert-score", "bitsandbytes", "boto3", "demjson3", "flax", "huggingface-hub", "jax", "jaxlib", "levenshtein", "openai", "outlines", "rouge-score", "rouge-score", "tiktoken", "vllm"]
 generative = ["bert-score", "bitsandbytes", "demjson3", "outlines", "rouge-score", "vllm"]
 jax = ["flax", "jax", "jaxlib"]
-olmo = ["ai2-olmo", "boto3", "huggingface-hub"]
-openai = ["levenshtein", "openai", "tiktoken"]
+olmo = ["ai2-olmo", "bert-score", "bitsandbytes", "boto3", "demjson3", "huggingface-hub", "outlines", "rouge-score", "vllm"]
+openai = ["bert-score", "bitsandbytes", "demjson3", "levenshtein", "openai", "outlines", "rouge-score", "tiktoken", "vllm"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "8b3759cfaf1687ff9b838d53a731a298d452fe6342c30db35660ca2f33050760"
+content-hash = "76e0a05196bf3e8edb709e80d0d264fcec18e32a29d020ba2a32c172b55dc2b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ bert-score = { version = "^0.3.13", optional = true }
 demjson3 = { version = "^3.0.6", optional = true }
 bitsandbytes = { markers = "sys_platform != 'darwin' or platform_machine != 'arm64'", version = "^0.42.0", optional = true }
 vllm = { markers = "sys_platform != 'darwin'", version = ">=0.3.3,<0.4.0", optional = true }
-outlines = { version = "^0.0.36", optional = true }
+outlines = { version = "^0.0.37", optional = true }
 
 # Needed for loading OLMO based models
 ai2-olmo = { version = "^0.2.4", optional = true }
@@ -83,11 +83,23 @@ generative = [
     "bert-score",
 ]
 olmo = [
+    "demjson3",
+    "outlines",
+    "bitsandbytes",
+    "vllm",
+    "rouge-score",
+    "bert-score",
     "ai2-olmo",
     "boto3",
     "huggingface-hub",
 ]
 openai = [
+    "demjson3",
+    "outlines",
+    "bitsandbytes",
+    "vllm",
+    "rouge-score",
+    "bert-score",
     "openai",
     "tiktoken",
     "levenshtein",

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -270,16 +270,8 @@ def generate_single_iteration(
 
         if isinstance(model, OpenAIModel):
             batch_size = 1
-
-        # VLLM models handle batching efficiently and do not require a fixed batch
-        # size. However, for the NER task we use the `outlines` package (with vLLM) for
-        # structured generation, and there is currently a bug causing outputs to be
-        # truncated when using a large batch size. So in this case we use the standard
-        # batch size. This will be reverted once the bug is fixed.
-        # Outlines issue: https://github.com/outlines-dev/outlines/issues/757
-        elif isinstance(model, VLLMModel) and not dataset_config.task == NER:
+        elif isinstance(model, VLLMModel):
             batch_size = len(torch_dataset)
-
         else:
             batch_size = benchmark_config.batch_size
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -275,6 +275,9 @@ def generate_single_iteration(
         else:
             batch_size = benchmark_config.batch_size
 
+        # TEMP
+        logger.debug(f"Batch size: {batch_size}")
+
         dataloader = DataLoader(
             dataset=torch_dataset,
             batch_size=batch_size,

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -275,9 +275,6 @@ def generate_single_iteration(
         else:
             batch_size = benchmark_config.batch_size
 
-        # TEMP
-        logger.debug(f"Batch size: {batch_size}")
-
         dataloader = DataLoader(
             dataset=torch_dataset,
             batch_size=batch_size,


### PR DESCRIPTION
### Changed
- Updated `outlines` dependency to v0.0.37, which can now correctly deal with a larger
  batch size when integrated with vLLM. This results in faster NER evaluation.