### PR TITLE
fix: Only enable OpenAI JSON mode if "json" is in the prompt

### DIFF
--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -505,7 +505,11 @@ class OpenAIModel:
             stop=["\n\n", self.tokenizer.eos_token, self.tokenizer.pad_token],
         )
 
-        if self.dataset_config.task == NER and self.supports_json_mode:
+        if (
+            self.dataset_config.task == NER
+            and self.supports_json_mode
+            and "json" in prompt.lower()
+        ):
             generation_kwargs["response_format"] = dict(type="json_object")
 
         try:


### PR DESCRIPTION
OpenAI JSON mode throws an error if the word "json" (case insensitive) doesn't appear in the prompt, so we only enable it if this is the case. This only happens during testing of sequence length and/or whether the model is generative, and not the actual samples.