### PR TITLE
Fix/chat template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Instruction tuned models are now using chat templates. This assumes that the
-  tokenizer has the `chat_template` set in its configuration.
 - Support for Azure OpenAI models! These can now be benchmarked as with any other
   model, where either the environment variables `AZURE_OPENAI_API_KEY`,
   `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_VERSION` need to have been set, or
@@ -30,6 +28,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Move models to the device before running any inference with it, as this causes issues
   when flash attention is enabled.
+- When benchmarking instruction tuned models, we now ensure that generation stops when
+  the end-of-chat token is reached (such as `<|im_end|>` and `[/INST]`). This had a
+  negative performance impact on question answering, but the remaining tasks were not
+  affected.
 
 
 ## [v12.3.2] - 2024-03-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   when flash attention is enabled.
 - When benchmarking instruction tuned models, we now ensure that generation stops when
   the end-of-chat token is reached (such as `<|im_end|>` and `[/INST]`). This had a
-  negative performance impact on question answering, but the remaining tasks were not
-  affected.
+  negative performance impact on question answering and summarization, but the
+  remaining tasks were not affected.
 
 
 ## [v12.3.2] - 2024-03-19

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -29,7 +29,6 @@ from .speed_benchmark import benchmark_speed
 from .tasks import SPEED
 from .utils import (
     GENERATIVE_MODEL_TASKS,
-    convert_prompt_to_instruction,
     enforce_reproducibility,
     model_is_generative,
     should_prompts_be_stripped,
@@ -490,15 +489,15 @@ class BenchmarkDataset(ABC):
                         )
 
                         # Apply chat template, if one is available
-                        test = test.map(
-                            function=lambda x: dict(
-                                text=convert_prompt_to_instruction(
-                                    prompt=x["text"], tokenizer=tokenizer
-                                )
-                            ),
-                            load_from_cache_file=False,
-                            keep_in_memory=True,
-                        )
+                        # test = test.map(
+                        #     function=lambda x: dict(
+                        #         text=convert_prompt_to_instruction(
+                        #             prompt=x["text"], tokenizer=tokenizer
+                        #         )
+                        #     ),
+                        #     load_from_cache_file=False,
+                        #     keep_in_memory=True,
+                        # )
 
                         # Determine if we should strip the prompts. This is the case if
                         # the tokenizer needs to include the space as part of the label

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -488,7 +488,9 @@ class BenchmarkDataset(ABC):
                             keep_in_memory=True,
                         )
 
-                        # Apply chat template, if one is available
+                        # NOTE: This applies the model's chat template if one is
+                        # available. However, all experiments have shown this to reduce
+                        # overall performance, so it is left out for now.
                         # test = test.map(
                         #     function=lambda x: dict(
                         #         text=convert_prompt_to_instruction(


### PR DESCRIPTION
### Fixed
- When benchmarking instruction tuned models, we now ensure that generation stops when
  the end-of-chat token is reached (such as `<|im_end|>` and `[/INST]`). This had a
  negative performance impact on question answering, but the remaining tasks were not
  affected.