### PR TITLE
Move Tensor to same device as dummy inputs

### DIFF
--- a/src/scandeval/model_setups/utils.py
+++ b/src/scandeval/model_setups/utils.py
@@ -173,7 +173,7 @@ def align_model_and_tokenizer(
             except ValueError as e:
                 if "decoder_input_ids" not in str(e):
                     raise e
-                model(input_ids=dummy_inputs, labels=torch.zeros(1, 1).long())
+                model(input_ids=dummy_inputs, labels=torch.zeros(1, 1).long().to(dummy_inputs.device))
                 break
 
             # This happens if `max_length` is too large


### PR DESCRIPTION
Hey guys, I was benchmarking some models - and one of these models happened to be a T5-based model. This would fail as the Torch.zeros() was not on the same device as the input_ids.