### PR TITLE
fix: Deal with no end-of-chat token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Deals with the case where an instruction tuned model does not use any special token
+  at the end of the chat, such as `<|im_end|>`. This holds for, e.g., Qwen models.
+
+
 ## [v12.4.0] - 2024-03-27
 ### Added
 - Support for Azure OpenAI models! These can now be benchmarked as with any other

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -696,13 +696,19 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
     assert isinstance(token_ids, list)
 
     for idx, token in enumerate(tokenizer.convert_ids_to_tokens(token_ids)):
+        token_id = tokenizer.convert_tokens_to_ids(token)
+        assert isinstance(token_id, int)
+        token = tokenizer.decode([token_id])
         if "†" in token:
             x_token_index = idx
             break
     else:
         raise ValueError("Could not find the 'x' token in the chat template.")
 
-    return token_ids[x_token_index + 1 :]
+    end_of_chat_tokens = token_ids[x_token_index + 1 :]
+    if len(end_of_chat_tokens) == 0:
+        return None
+    return end_of_chat_tokens
 
 
 def convert_prompt_to_instruction(prompt: str, tokenizer: "Tokenizer") -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,6 +118,8 @@ def test_should_prefix_space_be_added_to_labels(model_id, expected):
         ("occiglot/occiglot-7b-de-en-instruct", [32001, 28705, 13]),
         ("mhenrichsen/danskgpt-tiny", None),
         ("mhenrichsen/danskgpt-tiny-chat", [32000, 29871, 13]),
+        ("mayflowergmbh/Wiedervereinigung-7b-dpo", None),
+        ("Qwen/Qwen1.5-0.5B-Chat", None),
     ],
 )
 def test_get_end_of_chat_token_ids(model_id, expected):


### PR DESCRIPTION
### Fixed
- Deals with the case where an instruction tuned model does not use any special token
  at the end of the chat, such as `<|im_end|>`. This holds for, e.g., Qwen models.