### PR TITLE
feat: Add GPT-4-turbo to cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v12.5.1] - 2024-04-03
 ### Security
 - Now uses an access token to access datasets, allowing the datasets to not be
   publicly available on the Hugging Face Hub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+- Added GPT-4-turbo name variations to cached OpenAI model IDs. This means that we'll
+  be able to see if a model ID should be an OpenAI model, without an OpenAI API key.
+
+
 ## [v12.5.1] - 2024-04-03
 ### Security
 - Now uses an access token to access datasets, allowing the datasets to not be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ScandEval"
-version = "12.5.0"
+version = "12.5.1"
 description = "Evaluation of pretrained language models on mono- or multilingual language tasks."
 authors = ["Dan Saattrup Nielsen <dan.nielsen@alexandra.dk>"]
 maintainers = [

--- a/src/scandeval/model_setups/openai.py
+++ b/src/scandeval/model_setups/openai.py
@@ -33,9 +33,9 @@ logger = logging.getLogger(__package__)
 CACHED_OPENAI_MODEL_IDS: list[str] = [
     "ada|babbage|curie|davinci",
     "(code|text)-(ada|babbage|curie|davinci)-[0-9]{3}",
-    "gpt-3.5-turbo(-16k|-instruct)?(-[0-9]{4})?",
-    "gpt-4(-[0-9]{4})?",
-    "gpt-4-32k(-[0-9]{4})?",
+    "gpt-3.5-turbo(-16k|-instruct)?(-[0-9]{4})?(-preview)?",
+    "gpt-4(-[0-9]{4})?(-preview)?",
+    "gpt-4-32k(-[0-9]{4})?(-preview)?",
 ]
 
 
@@ -44,6 +44,8 @@ VOCAB_SIZE_MAPPING = {
     "(code|text)-davinci-00[2-9]": 50_281,
     "gpt-3.5-turbo(-16k)?(-[0-9]{4})?": 100_256,
     "gpt-4-(32k)?(-[0-9]{4})?": 100_256,
+    "gpt-4-[0-9]{4}-preview": 100_256,
+    "gpt-4-(vision|turbo)(-preview)?": 100_256,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": -1,
 }
 
@@ -56,6 +58,8 @@ MODEL_MAX_LENGTH_MAPPING = {
     "gpt-3.5-turbo-16k(-[0-9]{4})?": 16_384,
     "gpt-4(-[0-9]{4})?": 8_192,
     "gpt-4-32k(-[0-9]{4})?": 32_768,
+    "gpt-4-[0-9]{4}-preview": 128_000,
+    "gpt-4-(vision|turbo)(-preview)?": 128_000,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": -1,
 }
 
@@ -66,6 +70,8 @@ NUM_PARAMS_MAPPING = {
     "(text-)?curie(-001)?": 13_000_000_000,
     "((text|code)-)?davinci(-00[1-9])?": 175_000_000_000,
     "gpt-(3.5|4)-turbo-((16|32)k)?(-[0-9]{4})?": -1,
+    "gpt-4-[0-9]{4}-preview": -1,
+    "gpt-4-(vision|turbo)(-preview)?": -1,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": -1,
 }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,7 +119,7 @@ def test_should_prefix_space_be_added_to_labels(model_id, expected):
         ("mhenrichsen/danskgpt-tiny", None),
         ("mhenrichsen/danskgpt-tiny-chat", [32000, 29871, 13]),
         ("mayflowergmbh/Wiedervereinigung-7b-dpo", None),
-        ("Qwen/Qwen1.5-0.5B-Chat", None),
+        ("Qwen/Qwen1.5-0.5B-Chat", [151645, 198]),
     ],
 )
 def test_get_end_of_chat_token_ids(model_id, expected):


### PR DESCRIPTION
### Added
- Added GPT-4-turbo name variations to cached OpenAI model IDs. This means that we'll
  be able to see if a model ID should be an OpenAI model, without an OpenAI API key.