### PR TITLE
fix: OpenAI speed benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- The speed benchmark for OpenAI models was extremely slow, due to an issue with the
+  tokenizer. This has been fixed now.
+
+
 ## [v12.5.2] - 2024-04-04
 ### Fixed
 - Now using the same label order in the NER task as is in the dataset configuration.

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -155,13 +155,13 @@ def benchmark_speed_single_iteration(
         speed_scores = pyinfer.InferenceReport(
             model=predict, inputs=doc, n_seconds=3
         ).run(print_report=False)
-        num_tokens = len(tokenizer(doc, truncation=True)["input_ids"])
+        num_tokens = len(tokenizer([doc], truncation=True)["input_ids"][0])
         tokens_per_second = speed_scores["Infer(p/sec)"] * num_tokens
 
         speed_scores_short = pyinfer.InferenceReport(
             model=predict, inputs=short_doc, n_seconds=3
         ).run(print_report=False)
-        num_tokens_short = len(tokenizer(short_doc, truncation=True)["input_ids"])
+        num_tokens_short = len(tokenizer([short_doc], truncation=True)["input_ids"][0])
         tokens_per_second_short = speed_scores_short["Infer(p/sec)"] * num_tokens_short
 
         scores["test"] = dict(


### PR DESCRIPTION
### Fixed
- The speed benchmark for OpenAI models was extremely slow, due to an issue with the
  tokenizer. This has been fixed now.