### PR TITLE
Feat/reduce vllm vram usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   summarisation datasets. This has been fixed now.
 - Now correctly detects if `autoawq` should be installed, when evaluating an AWQ model.
 - Reduced `transformers` dependency to `4.38.x` again, as `autoawq` requires this.
+- Do not use BitsAndBytes quantisation if the model is already quantised.
 
 
 ## [v12.6.0] - 2024-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The number of allowed generated tokens for the Danish summarisation dataset
   Nordjylland News was mistakenly set to 128, compared to 256 for all other
   summarisation datasets. This has been fixed now.
+- Now correctly detects if `autoawq` should be installed, when evaluating an AWQ model.
+- Reduced `transformers` dependency to `4.38.x` again, as `autoawq` requires this.
 
 
 ## [v12.6.0] - 2024-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   which makes it possible to evaluate larger models on the same hardware as previously.
   Concretely, the `gpu_memory_utilization` has been raised from 0.9 to 0.95,
   `enforce_eager` is set to True, the `max_model_len` has been reduced from (at most)
-  10,000 to (at most) 5,000, and the `max_rolling_batch_prefill_tokens` has been set to
-  the same value as `max_model_len`, where we previously had not set it (defaulting to
-  the maximum context length from the Hugging Face model configuration). See [this
+  10,000 to (at most) 5,000. See [this
   issue](https://github.com/ScandEval/ScandEval/issues/383) for an overview of maximum
   amount of tokens in each dataset (as of v12.6.0 of ScandEval).
 - Removed 1 sample from the Swedish sentiment classification dataset SweReC which was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Changed
+- Changed vLLM inference parameters to limit the GPU memory usage during evaluation,
+  which makes it possible to evaluate larger models on the same hardware as previously.
+  Concretely, the `gpu_memory_utilization` has been raised from 0.9 to 0.95,
+  `enforce_eager` is set to True, the `max_model_len` has been reduced from (at most)
+  10,000 to (at most) 5,000, and the `max_rolling_batch_prefill_tokens` has been set to
+  the same value as `max_model_len`, where we previously had not set it (defaulting to
+  the maximum context length from the Hugging Face model configuration). See [this
+  issue](https://github.com/ScandEval/ScandEval/issues/383) for an overview of maximum
+  amount of tokens in each dataset (as of v12.6.0 of ScandEval).
+- Removed 1 sample from the Swedish sentiment classification dataset SweReC which was
+  abnormally long, to keep the maximum amount of tokens in the samples below 5,000.
+  Replaced the outlier sample with a new one.
+
+### Fixed
+- The number of allowed generated tokens for the Danish summarisation dataset
+  Nordjylland News was mistakenly set to 128, compared to 256 for all other
+  summarisation datasets. This has been fixed now.
+
+
 ## [v12.6.0] - 2024-04-10
 ### Changed
 - Updated `transformers` dependency to `>=4.39.3,<4.40.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Changed vLLM inference parameters to limit the GPU memory usage during evaluation,
   which makes it possible to evaluate larger models on the same hardware as previously.
   Concretely, the `gpu_memory_utilization` has been raised from 0.9 to 0.95,
@@ -18,8 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed 1 sample from the Swedish sentiment classification dataset SweReC which was
   abnormally long, to keep the maximum amount of tokens in the samples below 5,000.
   Replaced the outlier sample with a new one.
-
-### Fixed
 - The number of allowed generated tokens for the Danish summarisation dataset
   Nordjylland News was mistakenly set to 128, compared to 256 for all other
   summarisation datasets. This has been fixed now.

--- a/poetry.lock
+++ b/poetry.lock
@@ -289,6 +289,57 @@ test = ["parameterized", "pytest"]
 triton = ["triton (==2.0.0)"]
 
 [[package]]
+name = "autoawq"
+version = "0.2.4"
+description = "AutoAWQ implements the AWQ algorithm for 4-bit quantization with a 2x speedup during inference."
+optional = true
+python-versions = ">=3.8.0"
+files = [
+    {file = "autoawq-0.2.4-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:2d2cd3998fae46fc318efee0ebf563ccef8844bd16bfea45ad9f99c35b6f5b72"},
+    {file = "autoawq-0.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:fdd24d22ed8a02b8f58efaafa05a183660621efe1ed39cffade1175b0157f853"},
+    {file = "autoawq-0.2.4-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:c0c5ea7ccadaec526d7e83a0f9f4982a04de9f4537197d139cc95283c376bdc6"},
+    {file = "autoawq-0.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:8e836d6d27aacfa22d8e8fdd68dc0659ac9ae8cc7ea1de31ea6f4fc018072a0b"},
+    {file = "autoawq-0.2.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:5625cc2ae44c280938e3c152ed98916f7468b8461adbc7c0ed889cfab40dc042"},
+    {file = "autoawq-0.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:4f0ea63eca456207e898e10ec71664a23186e03fc5cb8f8d112cfd49e6cf54d8"},
+    {file = "autoawq-0.2.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:5039e7972025be5f14052ca58454a4ea92b05460ef5edcad1a306fc320aeba86"},
+    {file = "autoawq-0.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:8e01b776c2b5ad567a625982f1b2ca0e5317551a1a7990994adcc82377cedbbc"},
+]
+
+[package.dependencies]
+accelerate = "*"
+autoawq-kernels = "*"
+datasets = "*"
+tokenizers = ">=0.12.1"
+torch = ">=2.0.1"
+transformers = ">=4.35.0,<=4.38.2"
+typing-extensions = ">=4.8.0"
+zstandard = "*"
+
+[package.extras]
+dev = ["black", "griffe-typingdoc", "mkdocs-material", "mkdocstrings-python"]
+eval = ["evaluate", "lm-eval (>=0.4.0)", "protobuf", "scipy", "tabulate"]
+
+[[package]]
+name = "autoawq-kernels"
+version = "0.0.6"
+description = "AutoAWQ Kernels implements the AWQ kernels."
+optional = true
+python-versions = ">=3.8.0"
+files = [
+    {file = "autoawq_kernels-0.0.6-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e5d98d63e325ab3a51042b4aa87130bcd4d0fb9e7efc63dd4c307af3f44fcf05"},
+    {file = "autoawq_kernels-0.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:06e66e079cb24cfd4f93a7a190b45f8a36e1b7d418f8dfd85553455530e336a6"},
+    {file = "autoawq_kernels-0.0.6-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:eded9956bb3f3ad208ad2abde49c90ea5e17001175f2abb7edd5c9ac0156aeda"},
+    {file = "autoawq_kernels-0.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:28d61e7d04a9c582a77c667351deadba61e7a6596b58a86226f52d69df18a511"},
+    {file = "autoawq_kernels-0.0.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ea980771ec38a48405176ee1fcbc1afdd564b003bd73bf0e55194ed0977ee7f1"},
+    {file = "autoawq_kernels-0.0.6-cp38-cp38-win_amd64.whl", hash = "sha256:d62ea2be677a86f07263cc48959f104d42fece9a7b16395737f39ffc46d564d6"},
+    {file = "autoawq_kernels-0.0.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:7968f69c180e12f3c9f8deb2ec560b3423009d7b4bb637f993e75eb074780993"},
+    {file = "autoawq_kernels-0.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:1f5777e67d2780bb87a38965a157264e8245f653608b2ce64eeffc95488dcffc"},
+]
+
+[package.dependencies]
+torch = ">=2.0.1"
+
+[[package]]
 name = "bert-score"
 version = "0.3.13"
 description = "PyTorch implementation of BERT score"
@@ -404,6 +455,70 @@ files = [
     {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
     {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "cfgv"
@@ -3638,6 +3753,17 @@ files = [
 pyasn1 = ">=0.4.6,<0.6.0"
 
 [[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.6.4"
 description = "Data validation using Python type hints"
@@ -3930,6 +4056,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -3937,8 +4064,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -3955,6 +4090,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -3962,6 +4098,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -5249,13 +5386,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "transformers"
-version = "4.39.3"
+version = "4.38.2"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "transformers-4.39.3-py3-none-any.whl", hash = "sha256:7838034a12cca3168247f9d2d1dba6724c9de3ae0f73a108258c6b8fc5912601"},
-    {file = "transformers-4.39.3.tar.gz", hash = "sha256:2586e5ff4150f122716fc40f5530e92871befc051848fbe82600969c535b762d"},
+    {file = "transformers-4.38.2-py3-none-any.whl", hash = "sha256:c4029cb9f01b3dd335e52f364c52d2b37c65b4c78e02e6a08b1919c5c928573e"},
+    {file = "transformers-4.38.2.tar.gz", hash = "sha256:c5fc7ad682b8a50a48b2a4c05d4ea2de5567adb1bdd00053619dbe5960857dd5"},
 ]
 
 [package.dependencies]
@@ -5928,15 +6065,76 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
+[[package]]
+name = "zstandard"
+version = "0.22.0"
+description = "Zstandard bindings for Python"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:275df437ab03f8c033b8a2c181e51716c32d831082d93ce48002a5227ec93019"},
+    {file = "zstandard-0.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ac9957bc6d2403c4772c890916bf181b2653640da98f32e04b96e4d6fb3252a"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe3390c538f12437b859d815040763abc728955a52ca6ff9c5d4ac707c4ad98e"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1958100b8a1cc3f27fa21071a55cb2ed32e9e5df4c3c6e661c193437f171cba2"},
+    {file = "zstandard-0.22.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e1856c8313bc688d5df069e106a4bc962eef3d13372020cc6e3ebf5e045202"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1a90ba9a4c9c884bb876a14be2b1d216609385efb180393df40e5172e7ecf356"},
+    {file = "zstandard-0.22.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3db41c5e49ef73641d5111554e1d1d3af106410a6c1fb52cf68912ba7a343a0d"},
+    {file = "zstandard-0.22.0-cp310-cp310-win32.whl", hash = "sha256:d8593f8464fb64d58e8cb0b905b272d40184eac9a18d83cf8c10749c3eafcd7e"},
+    {file = "zstandard-0.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:f1a4b358947a65b94e2501ce3e078bbc929b039ede4679ddb0460829b12f7375"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:589402548251056878d2e7c8859286eb91bd841af117dbe4ab000e6450987e08"},
+    {file = "zstandard-0.22.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a97079b955b00b732c6f280d5023e0eefe359045e8b83b08cf0333af9ec78f26"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:445b47bc32de69d990ad0f34da0e20f535914623d1e506e74d6bc5c9dc40bb09"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33591d59f4956c9812f8063eff2e2c0065bc02050837f152574069f5f9f17775"},
+    {file = "zstandard-0.22.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:888196c9c8893a1e8ff5e89b8f894e7f4f0e64a5af4d8f3c410f0319128bb2f8"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:53866a9d8ab363271c9e80c7c2e9441814961d47f88c9bc3b248142c32141d94"},
+    {file = "zstandard-0.22.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4ac59d5d6910b220141c1737b79d4a5aa9e57466e7469a012ed42ce2d3995e88"},
+    {file = "zstandard-0.22.0-cp311-cp311-win32.whl", hash = "sha256:2b11ea433db22e720758cba584c9d661077121fcf60ab43351950ded20283440"},
+    {file = "zstandard-0.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:11f0d1aab9516a497137b41e3d3ed4bbf7b2ee2abc79e5c8b010ad286d7464bd"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6c25b8eb733d4e741246151d895dd0308137532737f337411160ff69ca24f93a"},
+    {file = "zstandard-0.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f9b2cde1cd1b2a10246dbc143ba49d942d14fb3d2b4bccf4618d475c65464912"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a88b7df61a292603e7cd662d92565d915796b094ffb3d206579aaebac6b85d5f"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466e6ad8caefb589ed281c076deb6f0cd330e8bc13c5035854ffb9c2014b118c"},
+    {file = "zstandard-0.22.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1d67d0d53d2a138f9e29d8acdabe11310c185e36f0a848efa104d4e40b808e4"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:39b2853efc9403927f9065cc48c9980649462acbdf81cd4f0cb773af2fd734bc"},
+    {file = "zstandard-0.22.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8a1b2effa96a5f019e72874969394edd393e2fbd6414a8208fea363a22803b45"},
+    {file = "zstandard-0.22.0-cp312-cp312-win32.whl", hash = "sha256:88c5b4b47a8a138338a07fc94e2ba3b1535f69247670abfe422de4e0b344aae2"},
+    {file = "zstandard-0.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:de20a212ef3d00d609d0b22eb7cc798d5a69035e81839f549b538eff4105d01c"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d75f693bb4e92c335e0645e8845e553cd09dc91616412d1d4650da835b5449df"},
+    {file = "zstandard-0.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:36a47636c3de227cd765e25a21dc5dace00539b82ddd99ee36abae38178eff9e"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68953dc84b244b053c0d5f137a21ae8287ecf51b20872eccf8eaac0302d3e3b0"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2612e9bb4977381184bb2463150336d0f7e014d6bb5d4a370f9a372d21916f69"},
+    {file = "zstandard-0.22.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:23d2b3c2b8e7e5a6cb7922f7c27d73a9a615f0a5ab5d0e03dd533c477de23004"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1d43501f5f31e22baf822720d82b5547f8a08f5386a883b32584a185675c8fbf"},
+    {file = "zstandard-0.22.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a493d470183ee620a3df1e6e55b3e4de8143c0ba1b16f3ded83208ea8ddfd91d"},
+    {file = "zstandard-0.22.0-cp38-cp38-win32.whl", hash = "sha256:7034d381789f45576ec3f1fa0e15d741828146439228dc3f7c59856c5bcd3292"},
+    {file = "zstandard-0.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:d8fff0f0c1d8bc5d866762ae95bd99d53282337af1be9dc0d88506b340e74b73"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2fdd53b806786bd6112d97c1f1e7841e5e4daa06810ab4b284026a1a0e484c0b"},
+    {file = "zstandard-0.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:73a1d6bd01961e9fd447162e137ed949c01bdb830dfca487c4a14e9742dccc93"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9501f36fac6b875c124243a379267d879262480bf85b1dbda61f5ad4d01b75a3"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48f260e4c7294ef275744210a4010f116048e0c95857befb7462e033f09442fe"},
+    {file = "zstandard-0.22.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959665072bd60f45c5b6b5d711f15bdefc9849dd5da9fb6c873e35f5d34d8cfb"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d22fdef58976457c65e2796e6730a3ea4a254f3ba83777ecfc8592ff8d77d303"},
+    {file = "zstandard-0.22.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a7ccf5825fd71d4542c8ab28d4d482aace885f5ebe4b40faaa290eed8e095a4c"},
+    {file = "zstandard-0.22.0-cp39-cp39-win32.whl", hash = "sha256:f058a77ef0ece4e210bb0450e68408d4223f728b109764676e1a13537d056bb0"},
+    {file = "zstandard-0.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:e9e9d4e2e336c529d4c435baad846a181e39a982f823f7e4495ec0b0ec8538d2"},
+    {file = "zstandard-0.22.0.tar.gz", hash = "sha256:8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\""}
+
+[package.extras]
+cffi = ["cffi (>=1.11)"]
+
 [extras]
-all = ["ai2-olmo", "auto-gptq", "bert-score", "bert-score", "bitsandbytes", "boto3", "demjson3", "flax", "huggingface-hub", "jax", "jaxlib", "levenshtein", "openai", "optimum", "outlines", "rouge-score", "rouge-score", "tiktoken", "vllm"]
+all = ["ai2-olmo", "auto-gptq", "autoawq", "bert-score", "bert-score", "bitsandbytes", "boto3", "demjson3", "flax", "huggingface-hub", "jax", "jaxlib", "levenshtein", "openai", "optimum", "outlines", "rouge-score", "rouge-score", "tiktoken", "transformers", "vllm"]
 generative = ["bert-score", "bitsandbytes", "demjson3", "outlines", "rouge-score", "vllm"]
-gptq = ["auto-gptq", "optimum"]
 jax = ["flax", "jax", "jaxlib"]
 olmo = ["ai2-olmo", "bert-score", "bitsandbytes", "boto3", "demjson3", "huggingface-hub", "outlines", "rouge-score", "vllm"]
 openai = ["bert-score", "bitsandbytes", "demjson3", "levenshtein", "openai", "outlines", "rouge-score", "tiktoken", "vllm"]
+quantization = ["auto-gptq", "autoawq", "optimum", "transformers"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "2096aa5ffc46a2c14596e06004092ccf093eeaa27b5e8ad0c074998195e57412"
+content-hash = "0b2ee7b06022c19420ced61cd4c02899947d5e5120db9a2a6fe9c3883cc1d95e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = ">=3.10,<3.12"
 torch = "^2.1.1"
 pandas = "^2.2.0"
 numpy = "^1.23.0"
-transformers = "~4.39.3"  # Only patch upgrades allowed as breaking changes happen often
+transformers = "~4.38.0"
 accelerate = "^0.26.0"
 evaluate = "^0.4.1"
 datasets = "^2.15.0"
@@ -61,6 +61,7 @@ levenshtein = { version = "^0.24.0", optional = true }
 # Needed for quantised models
 optimum = { version = "^1.18.0", optional = true }
 auto-gptq = { version = "^0.7.1", optional = true }
+autoawq = { version = "^0.2.4", optional = true }
 
 
 [tool.poetry.group.dev.dependencies]
@@ -109,9 +110,11 @@ openai = [
     "tiktoken",
     "levenshtein",
 ]
-gptq = [
+quantization = [
     "optimum",
     "auto-gptq",
+    "autoawq",
+    "transformers",
 ]
 all = [
     "jax",
@@ -133,6 +136,8 @@ all = [
     "levenshtein",
     "optimum",
     "auto-gptq",
+    "autoawq",
+    "transformers",
 ]
 
 [tool.poetry.scripts]

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -703,7 +703,7 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
     prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
     num_few_shot_examples=1,
-    max_generated_tokens=128,
+    max_generated_tokens=256,
 )
 
 MLSUM_CONFIG = DatasetConfig(

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -338,6 +338,14 @@ class HFModelSetup:
                     if self.benchmark_config.use_flash_attention
                     else None
                 ),
+                device_map=(
+                    "cuda:0"
+                    if (
+                        hasattr(config, "quantization_config")
+                        and config.quantization_config.get("quant_method") == "gptq"
+                    )
+                    else None
+                ),
             )
 
             # These are used when a timeout occurs

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -262,7 +262,7 @@ class HFModelSetup:
             load_in_4bit = (
                 model_config.task in GENERATIVE_MODEL_TASKS
                 and self.benchmark_config.device == torch.device("cuda")
-                and config.quantization_config is not None
+                and config.quantization_config is None
             )
 
         if load_in_4bit and importlib.util.find_spec("bitsandbytes") is None:

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -262,7 +262,10 @@ class HFModelSetup:
             load_in_4bit = (
                 model_config.task in GENERATIVE_MODEL_TASKS
                 and self.benchmark_config.device == torch.device("cuda")
-                and config.quantization_config is None
+                and (
+                    not hasattr(config, "quantization_config")
+                    or config.quantization_config is None
+                )
             )
 
         if load_in_4bit and importlib.util.find_spec("bitsandbytes") is None:

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -99,7 +99,7 @@ class VLLMModel:
             or importlib.util.find_spec("optimum") is None
         ):
             raise NeedsExtraInstalled(extra="quantization")
-        if quantization == "awq" and importlib.util.find_spec("autoawq") is None:
+        if quantization == "awq" and importlib.util.find_spec("awq") is None:
             raise NeedsExtraInstalled(extra="quantization")
 
         # Quantized models don't support bfloat16, so we need to set the dtype to

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -127,12 +127,13 @@ class VLLMModel:
             enable_prefix_caching=True,
         )
 
-        # We do a try-except here since `max_logprobs` is introduced in vLLM v0.4.0,
+        # We do a try-except here since some arguments are introduced in vLLM v0.4.0,
         # and we want to be able to use older versions of vLLM as well (for now)
         try:
             self._model = LLM(**vllm_kwargs)
         except TypeError:
             vllm_kwargs.pop("max_logprobs")
+            vllm_kwargs.pop("enable_prefix_caching")
             self._model = LLM(**vllm_kwargs)
 
         self._model._run_engine = MethodType(

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -127,7 +127,6 @@ class VLLMModel:
             enforce_eager=True,
             max_logprobs=10,
             enable_prefix_caching=True,
-            kv_cache_dtype="fp8_e5m2",
         )
 
         # We do a try-except here since some arguments are introduced in vLLM v0.4.0,

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -114,7 +114,6 @@ class VLLMModel:
             model=self.model_config.model_id,
             gpu_memory_utilization=0.95,
             max_model_len=self.max_model_len,
-            max_rolling_batch_prefill_tokens=self.max_model_len,
             download_dir=str(self.model_cache_dir),
             trust_remote_code=self.trust_remote_code,
             revision=self.model_config.revision,
@@ -124,6 +123,8 @@ class VLLMModel:
             quantization=quantization,
             dtype=dtype,
             enforce_eager=True,
+            max_logprobs=10,
+            enable_prefix_caching=True,
         )
         self._model._run_engine = MethodType(
             _run_engine_with_fixed_progress_bars, self._model

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -129,8 +129,9 @@ class VLLMModel:
             enable_prefix_caching=True,
         )
 
-        # We do a try-except here since some arguments are introduced in vLLM v0.4.0,
-        # and we want to be able to use older versions of vLLM as well (for now)
+        # TEMP: We do a try-except here since some arguments are introduced in vLLM
+        # v0.4.0, and we want to be able to use older versions of vLLM as well (for
+        # now)
         try:
             self._model = LLM(**vllm_kwargs)
         except TypeError:

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -127,6 +127,7 @@ class VLLMModel:
             enforce_eager=True,
             max_logprobs=10,
             enable_prefix_caching=True,
+            kv_cache_dtype="fp8_e5m2",
         )
 
         # We do a try-except here since some arguments are introduced in vLLM v0.4.0,

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -76,7 +76,7 @@ class VLLMModel:
         destroy_model_parallel()
         clear_memory()
 
-        self.max_model_len = 10_000
+        self.max_model_len = 5_000
         potential_max_model_length_config_names = [
             "max_position_embeddings",
             "max_sequence_length",
@@ -112,8 +112,9 @@ class VLLMModel:
 
         self._model = LLM(
             model=self.model_config.model_id,
-            gpu_memory_utilization=0.9,
+            gpu_memory_utilization=0.95,
             max_model_len=self.max_model_len,
+            max_rolling_batch_prefill_tokens=self.max_model_len,
             download_dir=str(self.model_cache_dir),
             trust_remote_code=self.trust_remote_code,
             revision=self.model_config.revision,
@@ -122,6 +123,7 @@ class VLLMModel:
             disable_custom_all_reduce=True,
             quantization=quantization,
             dtype=dtype,
+            enforce_eager=True,
         )
         self._model._run_engine = MethodType(
             _run_engine_with_fixed_progress_bars, self._model

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -93,12 +93,14 @@ class VLLMModel:
         if hasattr(self.config, "quantization_config"):
             quantization = self.config.quantization_config.get("quant_method", None)
 
-        # The GPTQ quantised models require extra dependencies
+        # The quantised models require extra dependencies
         if quantization == "gptq" and (
             importlib.util.find_spec("auto_gptq") is None
             or importlib.util.find_spec("optimum") is None
         ):
-            raise NeedsExtraInstalled(extra="gptq")
+            raise NeedsExtraInstalled(extra="quantization")
+        if quantization == "awq" and importlib.util.find_spec("autoawq") is None:
+            raise NeedsExtraInstalled(extra="quantization")
 
         # Quantized models don't support bfloat16, so we need to set the dtype to
         # float16 instead

--- a/src/scripts/constants.py
+++ b/src/scripts/constants.py
@@ -1,5 +1,10 @@
 """Constants used in the dataset creation scripts."""
 
+# Bounds on the size of texts in sequence classification datasets
+MIN_NUM_CHARS_IN_DOCUMENT = 2
+MAX_NUM_CHARS_IN_DOCUMENT = 5000
+
+
 # Bounds on the size of texts in question answering datasets
 MIN_NUM_CHARS_IN_CONTEXT = 30
 MAX_NUM_CHARS_IN_CONTEXT = 5000

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -95,12 +95,11 @@ def test_load_awq_model(awq_generative_model_id, dataset_config, benchmark_confi
     model_config = get_model_config(
         model_id=awq_generative_model_id, benchmark_config=benchmark_config
     )
-    with pytest.raises(InvalidModel):
-        load_model(
-            model_config=model_config,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
-        )
+    load_model(
+        model_config=model_config,
+        dataset_config=dataset_config,
+        benchmark_config=benchmark_config,
+    )
 
 
 @pytest.mark.skipif(condition=not torch.cuda.is_available(), reason="No GPU available.")
@@ -109,9 +108,8 @@ def test_load_gptq_model(gptq_generative_model_id, dataset_config, benchmark_con
     model_config = get_model_config(
         model_id=gptq_generative_model_id, benchmark_config=benchmark_config
     )
-    with pytest.raises(InvalidModel):
-        load_model(
-            model_config=model_config,
-            dataset_config=dataset_config,
-            benchmark_config=benchmark_config,
-        )
+    load_model(
+        model_config=model_config,
+        dataset_config=dataset_config,
+        benchmark_config=benchmark_config,
+    )


### PR DESCRIPTION
### Changed
- Changed vLLM inference parameters to limit the GPU memory usage during evaluation,
  which makes it possible to evaluate larger models on the same hardware as previously.
  Concretely, the `gpu_memory_utilization` has been raised from 0.9 to 0.95,
  `enforce_eager` is set to True, the `max_model_len` has been reduced from (at most)
  10,000 to (at most) 5,000. See [this
  issue](https://github.com/ScandEval/ScandEval/issues/383) for an overview of maximum
  amount of tokens in each dataset (as of v12.6.0 of ScandEval).
- Removed 1 sample from the Swedish sentiment classification dataset SweReC which was
  abnormally long, to keep the maximum amount of tokens in the samples below 5,000.
  Replaced the outlier sample with a new one.

### Fixed
- The number of allowed generated tokens for the Danish summarisation dataset
  Nordjylland News was mistakenly set to 128, compared to 256 for all other
  summarisation datasets. This has been fixed now.
- Now correctly detects if `autoawq` should be installed, when evaluating an AWQ model.
- Reduced `transformers` dependency to `4.38.x` again, as `autoawq` requires this.

This closes #383.