### PR TITLE
Fix/only use flash attention for generative models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When a model is generative then we use default context length to be 32,768.
 - Now ensures that we use mixed precision when CUDA is available, as this is required
   by Flash Attention.
+- By default we only use flash attention for generative models, as it leads to errors
+  with several encoder models.
 
 
 ## [v12.6.1] - 2024-04-11

--- a/poetry.lock
+++ b/poetry.lock
@@ -362,17 +362,22 @@ transformers = ">=3.0.0"
 
 [[package]]
 name = "bitsandbytes"
-version = "0.42.0"
+version = "0.43.1"
 description = "k-bit optimizers and matrix multiplication routines."
 optional = true
 python-versions = "*"
 files = [
-    {file = "bitsandbytes-0.42.0-py3-none-any.whl", hash = "sha256:63798680912cc63bb77b535a2d0860af024e290a52e157f777ad2a52e2585967"},
-    {file = "bitsandbytes-0.42.0.tar.gz", hash = "sha256:fc1505f184f0d275766f2a6c663f1a43b734c1409b5c5a406f3a6073d9f329fd"},
+    {file = "bitsandbytes-0.43.1-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:a81c826d576d6d691c7b4a7491c8fdc0f37f769795d6ca2e54afa605d2c260a3"},
+    {file = "bitsandbytes-0.43.1-py3-none-win_amd64.whl", hash = "sha256:52c1c7189a6ca006555a9663e544e75f40520a97a26e075411f9f9aca0771fcd"},
 ]
 
 [package.dependencies]
-scipy = "*"
+numpy = "*"
+torch = "*"
+
+[package.extras]
+benchmark = ["matplotlib", "pandas"]
+test = ["scipy"]
 
 [[package]]
 name = "boto3"
@@ -6126,4 +6131,4 @@ quantization = ["auto-gptq", "autoawq", "optimum"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "d0be9ece17522f46e529cff6a309869bcb669d0fdf7017c81a34a28c9ae9774c"
+content-hash = "843f969c4bb131cfdbcf46555e2be4ea0cb2ce5aa27e1cc2c2765a8685da135e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ sacremoses = "^0.1.1"
 rouge-score = { version = "^0.1.2", optional = true }
 bert-score = { version = "^0.3.13", optional = true }
 demjson3 = { version = "^3.0.6", optional = true }
-bitsandbytes = { markers = "sys_platform != 'darwin' or platform_machine != 'arm64'", version = "^0.42.0", optional = true }
+bitsandbytes = { markers = "sys_platform != 'darwin' or platform_machine != 'arm64'", version = "^0.43.1", optional = true }
 vllm = { markers = "sys_platform != 'darwin'", version = ">=0.3.3,<0.4.0", optional = true }
 outlines = { version = "^0.0.37", optional = true }
 

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -217,7 +217,8 @@ from .tasks import get_all_tasks
     default=None,
     show_default=True,
     help="""Whether to use Flash Attention. If not specified then the model will use
-    Flash Attention if possible.""",
+    Flash Attention for generative models, if a CUDA GPU is availabel and `flash-attn`
+    is installed.""",
 )
 @click.option(
     "--clear-model-cache/--no-clear-model-cache",
@@ -269,7 +270,7 @@ def benchmark(
     prefer_azure: bool,
     azure_openai_api_key: str | None,
     azure_openai_endpoint: str | None,
-    azure_openai_api_version: str |None,
+    azure_openai_api_version: str | None,
     force: bool,
     verbose: bool,
     framework: str | None,

--- a/src/scandeval/config.py
+++ b/src/scandeval/config.py
@@ -149,7 +149,8 @@ class BenchmarkConfig:
             Whether to load models in 4-bit precision. If None then this will be done
             if CUDA is available and the model is a decoder model.
         use_flash_attention:
-            Whether to use Flash Attention.
+            Whether to use Flash Attention. If None then this will be used for
+            generative models.
         clear_model_cache:
             Whether to clear the model cache after benchmarking each model.
         only_validation_split:
@@ -184,7 +185,7 @@ class BenchmarkConfig:
     verbose: bool
     trust_remote_code: bool
     load_in_4bit: bool | None
-    use_flash_attention: bool
+    use_flash_attention: bool | None
     clear_model_cache: bool
     only_validation_split: bool
     few_shot: bool

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -323,6 +323,11 @@ class HFModelSetup:
                 )
 
         if not use_vllm:
+            if self.benchmark_config.use_flash_attention is None:
+                flash_attention = model_config.task in GENERATIVE_MODEL_TASKS
+            else:
+                flash_attention = self.benchmark_config.use_flash_attention
+
             model_kwargs = dict(
                 config=config,
                 from_flax=from_flax,
@@ -333,12 +338,7 @@ class HFModelSetup:
                 trust_remote_code=self.benchmark_config.trust_remote_code,
                 quantization_config=bnb_config,
                 torch_dtype=self._get_torch_dtype(config=config),
-                attn_implementation=(
-                    "flash_attention_2"
-                    if self.benchmark_config.use_flash_attention
-                    and self.benchmark_config.device == torch.device("cuda")
-                    else None
-                ),
+                attn_implementation="flash_attention_2" if flash_attention else None,
                 device_map=(
                     "cuda:0"
                     if (


### PR DESCRIPTION
### Fixed
- By default we only use flash attention for generative models, as it leads to errors
  with several encoder models.