### PR TITLE
Fix/394 qa error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When a model is generative then we use default context length to be 32,768.
 - Now ensures that we use mixed precision when CUDA is available, as this is required
   by Flash Attention.
+- Use the decoded token IDs as keys in the model cache, rather than the original texts.
+  This caused issues when evaluating models with low context length, whose tokenizer
+  doesn't decode the token IDs back to the original texts.
 
 
 ## [v12.6.1] - 2024-04-11

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -227,7 +227,7 @@ def generate_single_iteration(
 
     # Split up the prepared dataset into a cached and non-cached part
     cached_dataset, non_cached_dataset = split_dataset_into_cached_and_non_cached(
-        dataset=prepared_dataset, cache=cache
+        dataset=prepared_dataset, cache=cache, tokenizer=tokenizer
     )
 
     all_preds: list[str | list[str]] = list()

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -242,8 +242,14 @@ def load_cached_model_outputs(
         The model output containing the cached sequences.
     """
     # Load the raw model outputs from the cache
+    dataset_texts = pd.Series(
+        [
+            tokenizer.decode(input_ids, skip_special_tokens=True)
+            for input_ids in cached_dataset["input_ids"]
+        ]
+    )
     cached_model_outputs: list[GenerativeModelOutput] = [
-        cache[prompt] for prompt in cached_dataset["text"]
+        cache[prompt] for prompt in dataset_texts
     ]
 
     # Tokenize the cached sequences

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -187,7 +187,7 @@ class ModelCache:
 
 
 def split_dataset_into_cached_and_non_cached(
-    dataset: "Dataset", cache: ModelCache
+    dataset: "Dataset", cache: ModelCache, tokenizer: "Tokenizer"
 ) -> tuple["Dataset", "Dataset"]:
     """Split a dataset into a cached and non-cached part.
 
@@ -196,13 +196,20 @@ def split_dataset_into_cached_and_non_cached(
             The dataset to split.
         cache:
             The model output cache.
+        tokenizer:
+            The tokenizer used to generate the tokens.
 
     Returns:
         The cached and non-cached parts of the dataset.
     """
     # Get the sample indices of the non-cached examples, which are unique with respect
-    # to the "text" column.
-    dataset_texts = pd.Series(dataset["text"])
+    # to the texts
+    dataset_texts = pd.Series(
+        [
+            tokenizer.decode(input_ids, skip_special_tokens=True)
+            for input_ids in dataset["input_ids"]
+        ]
+    )
     dataset_texts.drop_duplicates(inplace=True)
     unique_non_cached_ids = set(
         dataset_texts[~dataset_texts.isin(cache.cached_texts())].index.tolist()


### PR DESCRIPTION
### Fixed
- Use the decoded token IDs as keys in the model cache, rather than the original texts.
  This caused issues when evaluating models with low context length, whose tokenizer
  doesn't decode the token IDs back to the original texts.