### PR TITLE
Fix/normistral 7b warm instruct chat template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+        #- id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        #- id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add missing OpenAI models to the model cache, to checking model existence when no
   OpenAI key is specified.
 - Only imports from the `openai` package if it has been installed.
+- Improved detection of the end-of-chat tokens for instruction tuned models, which
+  previously caused errors when evaluating some instruction tuned models.
 
 
 ## [v12.6.1] - 2024-04-11

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -679,6 +679,10 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
     Returns:
         The token IDs used to end chats, or None if the tokenizer does not have a chat
         template.
+
+    Raises:
+        ValueError:
+            If the end-of-chat token could not be located.
     """
     if tokenizer.chat_template is None:
         return None
@@ -696,7 +700,8 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
             x_token_index = idx
             break
     else:
-        raise ValueError("Could not find the 'x' token in the chat template.")
+        breakpoint()
+        raise ValueError("Could not locate the end-of-chat token for the model.")
 
     end_of_chat_tokens = token_ids[x_token_index + 1 :]
     if len(end_of_chat_tokens) == 0:

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -688,7 +688,7 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
         return None
 
     token_ids = tokenizer.apply_chat_template(
-        conversation=[dict(role="user", content="†")]
+        conversation=[dict(role="user", content="X")]
     )
     assert isinstance(token_ids, list)
 
@@ -696,11 +696,10 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
         token_id = tokenizer.convert_tokens_to_ids(token)
         assert isinstance(token_id, int)
         token = tokenizer.decode([token_id])
-        if "†" in token:
+        if "X" in token:
             x_token_index = idx
             break
     else:
-        breakpoint()
         raise ValueError("Could not locate the end-of-chat token for the model.")
 
     end_of_chat_tokens = token_ids[x_token_index + 1 :]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,6 +120,8 @@ def test_should_prefix_space_be_added_to_labels(model_id, expected):
         ("mhenrichsen/danskgpt-tiny-chat", [32000, 29871, 13], "<|im_end|>"),
         ("mayflowergmbh/Wiedervereinigung-7b-dpo", None, None),
         ("Qwen/Qwen1.5-0.5B-Chat", [151645, 198], "<|im_end|>"),
+        ("norallm/normistral-7b-warm", None, None),
+        ("norallm/normistral-7b-warm-instruct", [4, 217], "<|im_end|>"),
     ],
 )
 def test_get_end_of_chat_token_ids(model_id, expected_token_ids, expected_string):


### PR DESCRIPTION
### Fixed
- Improved detection of the end-of-chat tokens for instruction tuned models, which
  previously caused errors when evaluating some instruction tuned models.