### PR TITLE
fix: Override benchmark params correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- When overriding benchmark configuration parameters in `Benchmarker.benchmark` then
+  these overridden parameters are now correctly used when building datasets.
+
+
 ## [v12.9.1] - 2024-04-30
 ### Fixed
 - Disables the prefix caching of vLLMs, as it has not been implemented with sliding

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
+from scandeval.config import BenchmarkConfig
+
 from .benchmark_config_factory import build_benchmark_config
 from .dataset_configs import get_all_dataset_configs
 from .dataset_factory import DatasetFactory
@@ -323,7 +325,6 @@ class Benchmarker:
         self.results_path = Path.cwd() / "scandeval_benchmark_results.jsonl"
 
         adjust_logging_level(verbose=self.benchmark_config.verbose)
-        self.dataset_factory = DatasetFactory(benchmark_config=self.benchmark_config)
 
     @property
     def benchmark_results(self) -> list[BenchmarkResult]:
@@ -595,6 +596,7 @@ class Benchmarker:
                         raise_errors=benchmark_config.raise_errors,
                         model=loaded_model,
                         tokenizer=loaded_tokenizer,
+                        benchmark_config=benchmark_config,
                     )
                 except InvalidModel as e:
                     if benchmark_config.raise_errors:
@@ -680,6 +682,7 @@ class Benchmarker:
         raise_errors: bool,
         model: "GenerativeModel | None",
         tokenizer: "Tokenizer | None",
+        benchmark_config: BenchmarkConfig,
     ) -> (
         tuple[BenchmarkResult, "GenerativeModel | None", "Tokenizer | None"]
         | dict[str, str]
@@ -697,6 +700,8 @@ class Benchmarker:
                 The pre-loaded model, if available.
             tokenizer:
                 The pre-loaded tokenizer, if available.
+            benchmark_config:
+                The benchmark configuration.
 
         Returns:
             The benchmark result, or a dictionary containing an error message.
@@ -710,7 +715,8 @@ class Benchmarker:
             )
         while True:
             try:
-                dataset = self.dataset_factory.build_dataset(dataset_config)
+                dataset_factory = DatasetFactory(benchmark_config=benchmark_config)
+                dataset = dataset_factory.build_dataset(dataset_config)
                 results, metadata_dict, model, tokenizer = dataset(
                     model_id=model_id, model=model, tokenizer=tokenizer
                 )


### PR DESCRIPTION
### Fixed
- When overriding benchmark configuration parameters in `Benchmarker.benchmark` then
  these overridden parameters are now correctly used when building datasets.