### PR TITLE
Fix/rebuild logits processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - When overriding benchmark configuration parameters in `Benchmarker.benchmark` then
   these overridden parameters are now correctly used when building datasets.
+- When a generative model was benchmarked on a NER task followed by another task, the
+  structured generation wasn't set up correctly, as we're not re-initialising the model
+  since v12.8.0. We now ensure that the logits processors are re-built for every
+  dataset.
 
 
 ## [v12.9.1] - 2024-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `transformers`.
 - Update `vllm` to `>=0.4.2,<0.5.0`, to support new models (such as Phi-3).
 - Update `torch` to `>=2.3.0,<3.0.0`, as this is required by `vllm`.
+- Enable prefix caching if the `sliding_window` attribute of the Hugging Face model
+  config has not been set (since this combination hasn't been implemented in vLLM yet).
 
 ### Fixed
 - When overriding benchmark configuration parameters in `Benchmarker.benchmark` then

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -18,6 +18,8 @@ from tqdm.auto import tqdm
 from transformers import Trainer
 from transformers.modeling_utils import PreTrainedModel
 
+from scandeval.vllm_models import VLLMModel
+
 from .exceptions import InvalidBenchmark
 from .finetuning import finetune
 from .generation import generate
@@ -146,6 +148,11 @@ class BenchmarkDataset(ABC):
                 dataset_config=self.dataset_config,
                 benchmark_config=self.benchmark_config,
             )
+
+        # For vLLM models we need to re-build the logits processors to ensure that the
+        # structured generation is only used for NER tasks
+        elif isinstance(model, VLLMModel):
+            model.build_logits_processors(dataset_config=self.dataset_config)
 
         benchmarking_generative_model = model_is_generative(model=model)
 

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -311,7 +311,6 @@ class HFModelSetup:
                 model = VLLMModel(
                     model_config=model_config,
                     hf_model_config=config,
-                    dataset_config=dataset_config,
                     model_cache_dir=model_config.model_cache_dir,
                     trust_remote_code=self.benchmark_config.trust_remote_code,
                 )
@@ -474,7 +473,7 @@ class HFModelSetup:
 
         if use_vllm:
             model.set_tokenizer(tokenizer=tokenizer)
-            model.build_logits_processors()
+            model.build_logits_processors(dataset_config=dataset_config)
 
         model, tokenizer = align_model_and_tokenizer(
             model=model,

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -169,6 +169,7 @@ def block_terminal_output():
     logging.getLogger("openai").setLevel(logging.CRITICAL)
     logging.getLogger("torch.distributed.distributed_c10d").setLevel(logging.CRITICAL)
     logging.getLogger("torch.nn.parallel.distributed").setLevel(logging.CRITICAL)
+    logging.getLogger("vllm").setLevel(logging.CRITICAL)
     logging.getLogger("vllm.engine.llm_engine").setLevel(logging.CRITICAL)
     logging.getLogger("vllm.transformers_utils.tokenizer").setLevel(logging.CRITICAL)
     logging.getLogger("vllm.core.scheduler").setLevel(logging.CRITICAL)

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -179,6 +179,7 @@ def block_terminal_output():
 
     # This suppresses vLLM logging
     os.environ["LOG_LEVEL"] = "CRITICAL"
+    os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
 
     if importlib.util.find_spec("ray") is not None:
         ray._private.worker._worker_logs_enabled = False

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -124,7 +124,7 @@ class VLLMModel:
             dtype=dtype,
             enforce_eager=True,
             max_logprobs=10,
-            enable_prefix_caching=True,  # TODO: We will support this in the future
+            enable_prefix_caching=False,  # TODO: We will support this in the future
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -15,7 +15,7 @@ from transformers.utils import ModelOutput
 from .exceptions import NeedsExtraInstalled
 from .structured_generation_utils import get_ner_logits_processors
 from .tasks import NER
-from .utils import block_terminal_output, clear_memory, get_end_of_chat_token_ids
+from .utils import clear_memory, get_end_of_chat_token_ids
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -29,7 +29,6 @@ if importlib.util.find_spec("ray") is not None:
     import ray
 
 if importlib.util.find_spec("vllm") is not None:
-    block_terminal_output()
     from vllm import LLM, SamplingParams
 
     try:

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -124,7 +124,9 @@ class VLLMModel:
             dtype=dtype,
             enforce_eager=True,
             max_logprobs=10,
-            enable_prefix_caching=False,  # TODO: We will support this in the future
+            # TEMP: Prefix caching isn't supported with sliding window in vLLM yet, so
+            # we disable it for now
+            enable_prefix_caching=not hasattr(self.config, "sliding_window"),
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -394,6 +394,9 @@ def _run_engine_with_fixed_progress_bars(
 
 def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
-    destroy_model_parallel()
+    try:
+        destroy_model_parallel()
+    except ImportError:
+        pass
     clear_memory()
     ray.shutdown()

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -313,7 +313,7 @@ class VLLMModel:
             inputs=inputs, generation_config=generation_config, **generation_kwargs
         )
 
-    def build_logits_processors(self, dataset_config: DatasetConfig) -> None:
+    def build_logits_processors(self, dataset_config: "DatasetConfig") -> None:
         """Return the logits processors to use for structured generation.
 
         This requires the model and tokenizer to be set.

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -119,12 +119,12 @@ class VLLMModel:
             revision=self.model_config.revision,
             seed=4242,
             tensor_parallel_size=torch.cuda.device_count(),
-            # disable_custom_all_reduce=True,
+            disable_custom_all_reduce=True,
             quantization=quantization,
             dtype=dtype,
-            # enforce_eager=True,
+            enforce_eager=True,
             max_logprobs=10,
-            enable_prefix_caching=False,  # TODO: We will support this in the future
+            enable_prefix_caching=True,  # TODO: We will support this in the future
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -15,7 +15,7 @@ from transformers.utils import ModelOutput
 from .exceptions import NeedsExtraInstalled
 from .structured_generation_utils import get_ner_logits_processors
 from .tasks import NER
-from .utils import clear_memory, get_end_of_chat_token_ids
+from .utils import block_terminal_output, clear_memory, get_end_of_chat_token_ids
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -127,6 +127,7 @@ class VLLMModel:
             enable_prefix_caching=False,  # TODO: We will support this in the future
         )
 
+        block_terminal_output()
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)
 
     def _initialise(self, vllm_kwargs: dict) -> "LLM":

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -126,7 +126,7 @@ class VLLMModel:
             max_logprobs=10,
             # TEMP: Prefix caching isn't supported with sliding window in vLLM yet, so
             # we disable it for now
-            enable_prefix_caching=not hasattr(self.config, "sliding_window"),
+            enable_prefix_caching=False,
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -119,10 +119,10 @@ class VLLMModel:
             revision=self.model_config.revision,
             seed=4242,
             tensor_parallel_size=torch.cuda.device_count(),
-            disable_custom_all_reduce=True,
+            # disable_custom_all_reduce=True,
             quantization=quantization,
             dtype=dtype,
-            enforce_eager=True,
+            # enforce_eager=True,
             max_logprobs=10,
             enable_prefix_caching=False,  # TODO: We will support this in the future
         )

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -124,7 +124,7 @@ class VLLMModel:
             dtype=dtype,
             enforce_eager=True,
             max_logprobs=10,
-            enable_prefix_caching=True,  # False,  # TODO: We will support this in the future
+            enable_prefix_caching=False,  # TODO: We will support this in the future
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -49,7 +49,6 @@ class VLLMModel:
         self,
         model_config: "ModelConfig",
         hf_model_config: "PretrainedConfig",
-        dataset_config: "DatasetConfig",
         model_cache_dir: "str | Path",
         trust_remote_code: bool,
         tokenizer: "PreTrainedTokenizerBase | None" = None,
@@ -61,8 +60,6 @@ class VLLMModel:
                 A model configuration.
             hf_model_config:
                 A Hugging Face model configuration.
-            dataset_config:
-                A dataset configuration.
             model_cache_dir:
                 The directory to cache the model in.
             trust_remote_code:
@@ -73,7 +70,6 @@ class VLLMModel:
         """
         self.model_config = model_config
         self.config = hf_model_config
-        self.dataset_config = dataset_config
         self.model_cache_dir = model_cache_dir
         self.trust_remote_code = trust_remote_code
         self.device = torch.device("cuda")
@@ -317,10 +313,14 @@ class VLLMModel:
             inputs=inputs, generation_config=generation_config, **generation_kwargs
         )
 
-    def build_logits_processors(self) -> None:
+    def build_logits_processors(self, dataset_config: DatasetConfig) -> None:
         """Return the logits processors to use for structured generation.
 
         This requires the model and tokenizer to be set.
+
+        Args:
+            dataset_config:
+                The dataset configuration to use for building the logits processors.
 
         Raises:
             ValueError:
@@ -331,8 +331,8 @@ class VLLMModel:
 
         logits_processors = list()
 
-        if self.dataset_config.task == NER:
-            ner_tag_names = list(self.dataset_config.prompt_label_mapping.values())
+        if dataset_config.task == NER:
+            ner_tag_names = list(dataset_config.prompt_label_mapping.values())
             ner_logits_processors = get_ner_logits_processors(
                 ner_tag_names=ner_tag_names, llm=self._model
             )

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -29,6 +29,7 @@ if importlib.util.find_spec("ray") is not None:
     import ray
 
 if importlib.util.find_spec("vllm") is not None:
+    block_terminal_output()
     from vllm import LLM, SamplingParams
 
     try:
@@ -127,7 +128,6 @@ class VLLMModel:
             enable_prefix_caching=False,  # TODO: We will support this in the future
         )
 
-        block_terminal_output()
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)
 
     def _initialise(self, vllm_kwargs: dict) -> "LLM":

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -124,7 +124,7 @@ class VLLMModel:
             dtype=dtype,
             enforce_eager=True,
             max_logprobs=10,
-            enable_prefix_caching=False,  # TODO: We will support this in the future
+            enable_prefix_caching=True,  # False,  # TODO: We will support this in the future
         )
 
         self._model = self._initialise(vllm_kwargs=vllm_kwargs)


### PR DESCRIPTION
### Fixed
- When a generative model was benchmarked on a NER task followed by another task, the
  structured generation wasn't set up correctly, as we're not re-initialising the model
  since v12.8.0. We now ensure that the logits processors are re-built for every
  dataset.