### PR TITLE
Chore/updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Now recognises the metadata for the new GPT-4o models correctly.
+- Now recognises the metadata for the new GPT-4o models correctly. Currently there is a
+  version clash between `vllm` and `tiktoken`, meaning that one needs to manually
+  upgrade `tiktoken` to evaluate GPT-4o - an informative error message notes this to
+  the user now in that case.
 
 
 ## [v12.10.0] - 2024-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Now recognises the metadata for the new GPT-4o models correctly.
+
+
 ## [v12.10.0] - 2024-05-08
 ### Changed
 - Update `autoawq` to `>=0.2.5,<0.3.0`, as it now doesn't have a dependency clash with

--- a/poetry.lock
+++ b/poetry.lock
@@ -6054,15 +6054,15 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-all = ["auto-gptq", "autoawq", "bert-score", "bert-score", "bitsandbytes", "demjson3", "flax", "gradio", "jax", "jaxlib", "levenshtein", "openai", "optimum", "outlines", "rouge-score", "rouge-score", "vllm"]
-cpu-all = ["bert-score", "bert-score", "demjson3", "flax", "gradio", "jax", "jaxlib", "levenshtein", "openai", "outlines", "rouge-score", "rouge-score"]
+all = ["auto-gptq", "autoawq", "bert-score", "bitsandbytes", "demjson3", "flax", "gradio", "jax", "jaxlib", "levenshtein", "openai", "optimum", "outlines", "rouge-score", "tiktoken", "vllm"]
+cpu-all = ["bert-score", "demjson3", "flax", "gradio", "jax", "jaxlib", "levenshtein", "openai", "outlines", "rouge-score", "tiktoken"]
 generative = ["bert-score", "bitsandbytes", "demjson3", "outlines", "rouge-score", "vllm"]
 human-evaluation = ["gradio", "levenshtein"]
 jax = ["flax", "jax", "jaxlib"]
-openai = ["bert-score", "bitsandbytes", "demjson3", "levenshtein", "openai", "outlines", "rouge-score", "vllm"]
+openai = ["bert-score", "levenshtein", "openai", "rouge-score", "tiktoken"]
 quantization = ["auto-gptq", "autoawq", "optimum"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "8350207d9583d16071bb7d96831a263f2666f7fca5a623bc3f705be57bab01bd"
+content-hash = "ab51bbeb52af557c628f79baddefdb5a52b936147776947f03900013a53743da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ flax = { version = "^0.8.1", optional = true }
 
 # Needed for evaluating OpenAI models
 openai = { version = "^1.11.1", optional = true }
+tiktoken = {version = "^0.6.0", optional = true}
 levenshtein = { version = "^0.24.0", optional = true }  # This is also used for human evaluation
 
 # Needed for quantised models
@@ -85,10 +86,6 @@ generative = [
     "bert-score",
 ]
 openai = [
-    "demjson3",
-    "outlines",
-    "bitsandbytes",
-    "vllm",
     "rouge-score",
     "bert-score",
     "openai",
@@ -114,8 +111,6 @@ all = [
     "outlines",
     "bitsandbytes",
     "vllm",
-    "rouge-score",
-    "bert-score",
     "openai",
     "tiktoken",
     "levenshtein",
@@ -132,8 +127,6 @@ cpu_all = [
     "bert-score",
     "demjson3",
     "outlines",
-    "rouge-score",
-    "bert-score",
     "openai",
     "tiktoken",
     "levenshtein",

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -62,7 +62,7 @@ SWEREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 ANGRY_TWEETS_CONFIG = DatasetConfig(
@@ -79,7 +79,7 @@ ANGRY_TWEETS_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 NOREC_CONFIG = DatasetConfig(
@@ -96,7 +96,7 @@ NOREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="nøytral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 # ISREC_CONFIG = DatasetConfig(
@@ -112,7 +112,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="jákvætt", neutral="hlutlaust", negative="neikvætt"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=1,
+#     max_generated_tokens=2,
 # )
 
 # FOREC_CONFIG = DatasetConfig(
@@ -128,7 +128,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="positivur", neutral="neutralur", negative="negativur"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=1,
+#     max_generated_tokens=2,
 # )
 
 SB10K_CONFIG = DatasetConfig(
@@ -145,7 +145,7 @@ SB10K_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 DUTCH_SOCIAL_CONFIG = DatasetConfig(
@@ -162,7 +162,7 @@ DUTCH_SOCIAL_CONFIG = DatasetConfig(
         positive="positief", neutral="neutraal", negative="negatief"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SST5_CONFIG = DatasetConfig(
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 # TODO: Icelandic Sentiment Classification
@@ -467,7 +467,7 @@ SCALA_SV_CONFIG = DatasetConfig(
     prompt_template="Mening: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_DA_CONFIG = DatasetConfig(
@@ -480,7 +480,7 @@ SCALA_DA_CONFIG = DatasetConfig(
     prompt_template="Sætning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_NB_CONFIG = DatasetConfig(
@@ -493,7 +493,7 @@ SCALA_NB_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_NN_CONFIG = DatasetConfig(
@@ -506,7 +506,7 @@ SCALA_NN_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_IS_CONFIG = DatasetConfig(
@@ -519,7 +519,7 @@ SCALA_IS_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nMálfræðilega rétt: {label}",
     prompt_label_mapping=dict(correct="já", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 
@@ -533,7 +533,7 @@ SCALA_FO_CONFIG = DatasetConfig(
     prompt_template="Setningur: {text}\nMállæruliga rættur: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_DE_CONFIG = DatasetConfig(
@@ -546,7 +546,7 @@ SCALA_DE_CONFIG = DatasetConfig(
     prompt_template="Satz: {text}\nGrammatikalisch richtig: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nein"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_NL_CONFIG = DatasetConfig(
@@ -559,7 +559,7 @@ SCALA_NL_CONFIG = DatasetConfig(
     prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nee"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 SCALA_EN_CONFIG = DatasetConfig(
@@ -573,7 +573,7 @@ SCALA_EN_CONFIG = DatasetConfig(
     prompt_template="Sentence: {text}\nGrammatically correct: {label}",
     prompt_label_mapping=dict(correct="yes", incorrect="no"),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 
@@ -702,7 +702,7 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     languages=[DA],
     prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
     prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -715,7 +715,7 @@ MLSUM_CONFIG = DatasetConfig(
     prompt_prefix="Im Folgenden finden Sie Nachrichtenartikel mit den dazugehörigen "
     "Zusammenfassungen.",
     prompt_template="Nachrichtenartikel: {text}\nZusammenfassung: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -728,7 +728,7 @@ RRN_CONFIG = DatasetConfig(
     languages=[IS],
     prompt_prefix="Eftirfarandi eru fréttagreinar með tilheyrandi samantektum.",
     prompt_template="Fréttagrein: {text}\nSamantekt: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -741,7 +741,7 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     languages=[NB, NN, NO],
     prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
     prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -754,7 +754,7 @@ WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     languages=[NL],
     prompt_prefix="Hieronder volgen artikelen met bijbehorende samenvattingen.",
     prompt_template="Artikel: {text}\nSamenvatting: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -766,7 +766,7 @@ SWEDN_CONFIG = DatasetConfig(
     languages=[SV],
     prompt_prefix="Nedan följer artiklar med tillhörande sammanfattningar.",
     prompt_template="Artikel: {text}\nSammanfattning: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -779,7 +779,7 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     languages=[EN],
     prompt_prefix="The following are articles with accompanying summaries.",
     prompt_template="News article: {text}\nSummary: {target_text}",
-    num_few_shot_examples=1,
+    num_few_shot_examples=2,
     max_generated_tokens=256,
 )
 
@@ -799,7 +799,7 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     prompt_template="Hvad er betydningen af følgende talemåde: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
@@ -812,7 +812,7 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_NO_CONFIG = DatasetConfig(
@@ -826,7 +826,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_SV_CONFIG = DatasetConfig(
@@ -840,7 +840,7 @@ MMLU_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_IS_CONFIG = DatasetConfig(
@@ -854,7 +854,7 @@ MMLU_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_DE_CONFIG = DatasetConfig(
@@ -868,7 +868,7 @@ MMLU_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_NL_CONFIG = DatasetConfig(
@@ -882,7 +882,7 @@ MMLU_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_CONFIG = DatasetConfig(
@@ -895,7 +895,7 @@ MMLU_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 MMLU_DA_CONFIG = DatasetConfig(
@@ -909,7 +909,7 @@ MMLU_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -924,7 +924,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -939,7 +939,7 @@ ARC_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -954,7 +954,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -969,7 +969,7 @@ ARC_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -984,7 +984,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -999,7 +999,7 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -1013,7 +1013,7 @@ ARC_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -1033,7 +1033,7 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_NO_CONFIG = DatasetConfig(
@@ -1047,7 +1047,7 @@ HELLASWAG_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_SV_CONFIG = DatasetConfig(
@@ -1061,7 +1061,7 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_IS_CONFIG = DatasetConfig(
@@ -1075,7 +1075,7 @@ HELLASWAG_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
     unofficial=True,
 )
 
@@ -1090,7 +1090,7 @@ WINOGRANDE_IS = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
@@ -1104,7 +1104,7 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_NL_CONFIG = DatasetConfig(
@@ -1118,7 +1118,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 HELLASWAG_CONFIG = DatasetConfig(
@@ -1132,7 +1132,7 @@ HELLASWAG_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=1,
+    max_generated_tokens=2,
 )
 
 # TODO: Faroese common sense reasoning

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -62,7 +62,7 @@ SWEREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 ANGRY_TWEETS_CONFIG = DatasetConfig(
@@ -79,7 +79,7 @@ ANGRY_TWEETS_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 NOREC_CONFIG = DatasetConfig(
@@ -96,7 +96,7 @@ NOREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="nøytral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 # ISREC_CONFIG = DatasetConfig(
@@ -112,7 +112,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="jákvætt", neutral="hlutlaust", negative="neikvætt"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=3,
+#     max_generated_tokens=1,
 # )
 
 # FOREC_CONFIG = DatasetConfig(
@@ -128,7 +128,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="positivur", neutral="neutralur", negative="negativur"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=3,
+#     max_generated_tokens=1,
 # )
 
 SB10K_CONFIG = DatasetConfig(
@@ -145,7 +145,7 @@ SB10K_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 DUTCH_SOCIAL_CONFIG = DatasetConfig(
@@ -162,7 +162,7 @@ DUTCH_SOCIAL_CONFIG = DatasetConfig(
         positive="positief", neutral="neutraal", negative="negatief"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SST5_CONFIG = DatasetConfig(
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 # TODO: Icelandic Sentiment Classification
@@ -467,7 +467,7 @@ SCALA_SV_CONFIG = DatasetConfig(
     prompt_template="Mening: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_DA_CONFIG = DatasetConfig(
@@ -480,7 +480,7 @@ SCALA_DA_CONFIG = DatasetConfig(
     prompt_template="Sætning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_NB_CONFIG = DatasetConfig(
@@ -493,7 +493,7 @@ SCALA_NB_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_NN_CONFIG = DatasetConfig(
@@ -506,7 +506,7 @@ SCALA_NN_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_IS_CONFIG = DatasetConfig(
@@ -519,7 +519,7 @@ SCALA_IS_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nMálfræðilega rétt: {label}",
     prompt_label_mapping=dict(correct="já", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 
@@ -533,7 +533,7 @@ SCALA_FO_CONFIG = DatasetConfig(
     prompt_template="Setningur: {text}\nMállæruliga rættur: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_DE_CONFIG = DatasetConfig(
@@ -546,7 +546,7 @@ SCALA_DE_CONFIG = DatasetConfig(
     prompt_template="Satz: {text}\nGrammatikalisch richtig: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nein"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_NL_CONFIG = DatasetConfig(
@@ -559,7 +559,7 @@ SCALA_NL_CONFIG = DatasetConfig(
     prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nee"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 SCALA_EN_CONFIG = DatasetConfig(
@@ -573,7 +573,7 @@ SCALA_EN_CONFIG = DatasetConfig(
     prompt_template="Sentence: {text}\nGrammatically correct: {label}",
     prompt_label_mapping=dict(correct="yes", incorrect="no"),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 
@@ -799,7 +799,7 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     prompt_template="Hvad er betydningen af følgende talemåde: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
@@ -812,7 +812,7 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_NO_CONFIG = DatasetConfig(
@@ -826,7 +826,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_SV_CONFIG = DatasetConfig(
@@ -840,7 +840,7 @@ MMLU_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_IS_CONFIG = DatasetConfig(
@@ -854,7 +854,7 @@ MMLU_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_DE_CONFIG = DatasetConfig(
@@ -868,7 +868,7 @@ MMLU_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_NL_CONFIG = DatasetConfig(
@@ -882,7 +882,7 @@ MMLU_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_CONFIG = DatasetConfig(
@@ -895,7 +895,7 @@ MMLU_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 MMLU_DA_CONFIG = DatasetConfig(
@@ -909,7 +909,7 @@ MMLU_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -924,7 +924,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -939,7 +939,7 @@ ARC_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -954,7 +954,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -969,7 +969,7 @@ ARC_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -984,7 +984,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -999,7 +999,7 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1013,7 +1013,7 @@ ARC_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1033,7 +1033,7 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_NO_CONFIG = DatasetConfig(
@@ -1047,7 +1047,7 @@ HELLASWAG_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_SV_CONFIG = DatasetConfig(
@@ -1061,7 +1061,7 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_IS_CONFIG = DatasetConfig(
@@ -1075,7 +1075,7 @@ HELLASWAG_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1090,7 +1090,7 @@ WINOGRANDE_IS = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
@@ -1104,7 +1104,7 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_NL_CONFIG = DatasetConfig(
@@ -1118,7 +1118,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_CONFIG = DatasetConfig(
@@ -1132,7 +1132,7 @@ HELLASWAG_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=3,
+    max_generated_tokens=1,
 )
 
 # TODO: Faroese common sense reasoning

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -62,7 +62,7 @@ SWEREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 ANGRY_TWEETS_CONFIG = DatasetConfig(
@@ -79,7 +79,7 @@ ANGRY_TWEETS_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 NOREC_CONFIG = DatasetConfig(
@@ -96,7 +96,7 @@ NOREC_CONFIG = DatasetConfig(
         positive="positiv", neutral="nøytral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 # ISREC_CONFIG = DatasetConfig(
@@ -112,7 +112,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="jákvætt", neutral="hlutlaust", negative="neikvætt"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=2,
+#     max_generated_tokens=1,
 # )
 
 # FOREC_CONFIG = DatasetConfig(
@@ -128,7 +128,7 @@ NOREC_CONFIG = DatasetConfig(
 #         positive="positivur", neutral="neutralur", negative="negativur"
 #     ),
 #     num_few_shot_examples=12,
-#     max_generated_tokens=2,
+#     max_generated_tokens=1,
 # )
 
 SB10K_CONFIG = DatasetConfig(
@@ -145,7 +145,7 @@ SB10K_CONFIG = DatasetConfig(
         positive="positiv", neutral="neutral", negative="negativ"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 DUTCH_SOCIAL_CONFIG = DatasetConfig(
@@ -162,7 +162,7 @@ DUTCH_SOCIAL_CONFIG = DatasetConfig(
         positive="positief", neutral="neutraal", negative="negatief"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SST5_CONFIG = DatasetConfig(
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 # TODO: Icelandic Sentiment Classification
@@ -467,7 +467,7 @@ SCALA_SV_CONFIG = DatasetConfig(
     prompt_template="Mening: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_DA_CONFIG = DatasetConfig(
@@ -480,7 +480,7 @@ SCALA_DA_CONFIG = DatasetConfig(
     prompt_template="Sætning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nej"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_NB_CONFIG = DatasetConfig(
@@ -493,7 +493,7 @@ SCALA_NB_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_NN_CONFIG = DatasetConfig(
@@ -506,7 +506,7 @@ SCALA_NN_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nGrammatisk korrekt: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_IS_CONFIG = DatasetConfig(
@@ -519,7 +519,7 @@ SCALA_IS_CONFIG = DatasetConfig(
     prompt_template="Setning: {text}\nMálfræðilega rétt: {label}",
     prompt_label_mapping=dict(correct="já", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 
@@ -533,7 +533,7 @@ SCALA_FO_CONFIG = DatasetConfig(
     prompt_template="Setningur: {text}\nMállæruliga rættur: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nei"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_DE_CONFIG = DatasetConfig(
@@ -546,7 +546,7 @@ SCALA_DE_CONFIG = DatasetConfig(
     prompt_template="Satz: {text}\nGrammatikalisch richtig: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nein"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_NL_CONFIG = DatasetConfig(
@@ -559,7 +559,7 @@ SCALA_NL_CONFIG = DatasetConfig(
     prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
     prompt_label_mapping=dict(correct="ja", incorrect="nee"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 SCALA_EN_CONFIG = DatasetConfig(
@@ -573,7 +573,7 @@ SCALA_EN_CONFIG = DatasetConfig(
     prompt_template="Sentence: {text}\nGrammatically correct: {label}",
     prompt_label_mapping=dict(correct="yes", incorrect="no"),
     num_few_shot_examples=12,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 
@@ -702,7 +702,7 @@ NORDJYLLAND_NEWS_CONFIG = DatasetConfig(
     languages=[DA],
     prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
     prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -715,7 +715,7 @@ MLSUM_CONFIG = DatasetConfig(
     prompt_prefix="Im Folgenden finden Sie Nachrichtenartikel mit den dazugehörigen "
     "Zusammenfassungen.",
     prompt_template="Nachrichtenartikel: {text}\nZusammenfassung: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -728,7 +728,7 @@ RRN_CONFIG = DatasetConfig(
     languages=[IS],
     prompt_prefix="Eftirfarandi eru fréttagreinar með tilheyrandi samantektum.",
     prompt_template="Fréttagrein: {text}\nSamantekt: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -741,7 +741,7 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     languages=[NB, NN, NO],
     prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
     prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -754,7 +754,7 @@ WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     languages=[NL],
     prompt_prefix="Hieronder volgen artikelen met bijbehorende samenvattingen.",
     prompt_template="Artikel: {text}\nSamenvatting: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -766,7 +766,7 @@ SWEDN_CONFIG = DatasetConfig(
     languages=[SV],
     prompt_prefix="Nedan följer artiklar med tillhörande sammanfattningar.",
     prompt_template="Artikel: {text}\nSammanfattning: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -779,7 +779,7 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     languages=[EN],
     prompt_prefix="The following are articles with accompanying summaries.",
     prompt_template="News article: {text}\nSummary: {target_text}",
-    num_few_shot_examples=2,
+    num_few_shot_examples=1,
     max_generated_tokens=256,
 )
 
@@ -799,7 +799,7 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     prompt_template="Hvad er betydningen af følgende talemåde: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
@@ -812,7 +812,7 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_NO_CONFIG = DatasetConfig(
@@ -826,7 +826,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_SV_CONFIG = DatasetConfig(
@@ -840,7 +840,7 @@ MMLU_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_IS_CONFIG = DatasetConfig(
@@ -854,7 +854,7 @@ MMLU_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_DE_CONFIG = DatasetConfig(
@@ -868,7 +868,7 @@ MMLU_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_NL_CONFIG = DatasetConfig(
@@ -882,7 +882,7 @@ MMLU_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_CONFIG = DatasetConfig(
@@ -895,7 +895,7 @@ MMLU_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 MMLU_DA_CONFIG = DatasetConfig(
@@ -909,7 +909,7 @@ MMLU_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -924,7 +924,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -939,7 +939,7 @@ ARC_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -954,7 +954,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -969,7 +969,7 @@ ARC_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -984,7 +984,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -999,7 +999,7 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1013,7 +1013,7 @@ ARC_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1033,7 +1033,7 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_NO_CONFIG = DatasetConfig(
@@ -1047,7 +1047,7 @@ HELLASWAG_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_SV_CONFIG = DatasetConfig(
@@ -1061,7 +1061,7 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_IS_CONFIG = DatasetConfig(
@@ -1075,7 +1075,7 @@ HELLASWAG_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
     unofficial=True,
 )
 
@@ -1090,7 +1090,7 @@ WINOGRANDE_IS = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_DE_CONFIG = DatasetConfig(
@@ -1104,7 +1104,7 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_NL_CONFIG = DatasetConfig(
@@ -1118,7 +1118,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 HELLASWAG_CONFIG = DatasetConfig(
@@ -1132,7 +1132,7 @@ HELLASWAG_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
-    max_generated_tokens=2,
+    max_generated_tokens=1,
 )
 
 # TODO: Faroese common sense reasoning

--- a/src/scandeval/model_setups/openai.py
+++ b/src/scandeval/model_setups/openai.py
@@ -49,22 +49,24 @@ VOCAB_SIZE_MAPPING = {
     "gpt-4-turbo(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": 100_256,
     "gpt-4-(vision|turbo)(-preview)?": 100_256,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": 100_256,
+    "gpt-4o(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": 200_019,
 }
 
 
 MODEL_MAX_LENGTH_MAPPING = {
-    "(text-)?(ada|babbage|curie|davinci)(-001)?": 2_049,
-    "text-davinci-00[2-9]": 4_097,
-    "code-davinci-00[1-9]": 8_001,
-    "gpt-3.5-turbo-0613": 4_095,
-    "gpt-3.5-turbo(-[0-9]{4})?": 16_384,
+    "(text-)?(ada|babbage|curie|davinci)(-001)?": 2_050,
+    "text-davinci-00[2-9]": 4_098,
+    "code-davinci-00[1-9]": 8_002,
+    "gpt-3.5-turbo-0613": 4_096,
+    "gpt-3.5-turbo(-[0-9]{4})?": 16_385,
     "gpt-3.5-turbo-16k(-[0-9]{4})?": 16_384,
     "gpt-4(-[0-9]{4})?": 8_191,
     "gpt-4-32k(-[0-9]{4})?": 32_767,
-    "gpt-4-[0-9]{4}-preview": 127_999,
-    "gpt-4-turbo(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": 127_999,
-    "gpt-4-(vision|turbo)(-preview)?": 127_999,
+    "gpt-4-[0-9]{4}-preview": 128_000,
+    "gpt-4-turbo(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": 128_000,
+    "gpt-4-(vision|turbo)(-preview)?": 128_000,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": 4_095,
+    "gpt-4o(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": 128_000,
 }
 
 
@@ -78,6 +80,7 @@ NUM_PARAMS_MAPPING = {
     "gpt-4-turbo(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": -1,
     "gpt-4-(vision|turbo)(-preview)?": -1,
     "gpt-3.5-turbo-instruct(-[0-9]{4})?": -1,
+    "gpt-4o(-[0-9]{4}-[0-9]{2}-[0-9]{2})?": -1,
 }
 
 


### PR DESCRIPTION
### Fixed
- Now recognises the metadata for the new GPT-4o models correctly. Currently there is a
  version clash between `vllm` and `tiktoken`, meaning that one needs to manually
  upgrade `tiktoken` to evaluate GPT-4o - an informative error message notes this to
  the user now in that case.