### PR TITLE
Fix/gpt 4 turbo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-### Added
-- We now use logprobs for OpenAI models, as this is supported by the chat models now.
-  This is used for all sequence classification based tasks, which currently comprise of
-  sentiment classification, linguistic acceptability, knowledge and common-sense
-  reasoning.
-
 ### Fixed
 - Correctly update logits processors and prefix allowed functions tokens functions for
   NER datasets when starting generation.
+- We now use logprobs for OpenAI models, as this is supported by the chat models now.
+  This is used for all sequence classification based tasks, which currently comprise of
+  sentiment classification, linguistic acceptability, knowledge and common-sense
+  reasoning. This fixes some incorrect evaluations of the newer GPT-4-turbo and GPT-4o
+  models, as they tend to output things like "Sentiment: positive" rather than simply
+  "positive".
 
 
 ## [v12.10.1] - 2024-05-28

--- a/makefile
+++ b/makefile
@@ -86,9 +86,9 @@ setup-environment-variables-non-interactive:
 test:  ## Run tests
 	@if [ "$(shell which nvidia-smi)" != "" ]; then \
 		$(MAKE) --quiet test-cuda-vllm; \
-		$(MAKE) --quiet test-cuda-no-vllm; \
+	else \
+		$(MAKE) --quiet test-cpu; \
 	fi
-	@$(MAKE) --quiet test-cpu
 	@$(MAKE) --quiet update-coverage-badge
 	@date "+%H:%M:%S ⋅ All done!"
 
@@ -119,8 +119,15 @@ test-fast:  # Run CPU tests without evaluations
 			poetry run pytest | tee tests_with_cpu_fast.log \
 		&& date "+%H:%M:%S ⋅ Finished fast testing with CPU!"
 
-test-slow:  # Run tests with all datasets
-	@TEST_ALL_DATASETS=1 $(MAKE) --quiet test
+test-slow:  # Run all tests
+	@if [ "$(shell which nvidia-smi)" != "" ]; then \
+		TEST_ALL_DATASETS=1 $(MAKE) --quiet test-cuda-vllm; \
+		TEST_ALL_DATASETS=1 $(MAKE) --quiet test-cuda-no-vllm; \
+	else \
+		TEST_ALL_DATASETS=1 $(MAKE) --quiet test-cpu; \
+	fi
+	@$(MAKE) --quiet update-coverage-badge
+	@date "+%H:%M:%S ⋅ All done!"
 
 update-coverage-badge:
 	@poetry run readme-cov

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -388,9 +388,6 @@ class BenchmarkDataset(ABC):
         val = dataset_dict["val"]
         test = dataset_dict["test"]
 
-        # TEMP
-        test = test.select(range(5))
-
         if self.benchmark_config.only_validation_split:
             test = val
 
@@ -404,6 +401,9 @@ class BenchmarkDataset(ABC):
         # If we are testing then truncate the test set
         if hasattr(sys, "_called_from_test"):
             test = test.select(range(1))
+
+        # TEMP
+        test = test.select(range(5))
 
         # Bootstrap the test set
         test_bidxs = rng.integers(

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -403,7 +403,7 @@ class BenchmarkDataset(ABC):
             test = test.select(range(1))
 
         # TEMP
-        test = test.select(range(25))
+        # test = test.select(range(25))
 
         # Bootstrap the test set
         test_bidxs = rng.integers(

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -403,7 +403,7 @@ class BenchmarkDataset(ABC):
             test = test.select(range(1))
 
         # TEMP
-        # test = test.select(range(5))
+        test = test.select(range(25))
 
         # Bootstrap the test set
         test_bidxs = rng.integers(

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -403,7 +403,7 @@ class BenchmarkDataset(ABC):
             test = test.select(range(1))
 
         # TEMP
-        test = test.select(range(5))
+        # test = test.select(range(5))
 
         # Bootstrap the test set
         test_bidxs = rng.integers(

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -402,6 +402,9 @@ class BenchmarkDataset(ABC):
         if hasattr(sys, "_called_from_test"):
             test = test.select(range(1))
 
+        # TEMP
+        test = test.select(range(5))
+
         # Bootstrap the test set
         test_bidxs = rng.integers(
             0, len(test), size=(self.benchmark_config.num_iterations, len(test))

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -402,9 +402,6 @@ class BenchmarkDataset(ABC):
         if hasattr(sys, "_called_from_test"):
             test = test.select(range(1))
 
-        # TEMP
-        test = test.select(range(5))
-
         # Bootstrap the test set
         test_bidxs = rng.integers(
             0, len(test), size=(self.benchmark_config.num_iterations, len(test))

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -402,9 +402,6 @@ class BenchmarkDataset(ABC):
         if hasattr(sys, "_called_from_test"):
             test = test.select(range(1))
 
-        # TEMP
-        # test = test.select(range(25))
-
         # Bootstrap the test set
         test_bidxs = rng.integers(
             0, len(test), size=(self.benchmark_config.num_iterations, len(test))

--- a/src/scandeval/benchmark_dataset.py
+++ b/src/scandeval/benchmark_dataset.py
@@ -388,6 +388,9 @@ class BenchmarkDataset(ABC):
         val = dataset_dict["val"]
         test = dataset_dict["test"]
 
+        # TEMP
+        test = test.select(range(5))
+
         if self.benchmark_config.only_validation_split:
             test = val
 

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=3,
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=10,
+    max_generated_tokens=10,  # TEMP
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=10,  # TEMP
+    max_generated_tokens=1,
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=10,  # TEMP
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=10,
+    max_generated_tokens=1,
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=1,
+    max_generated_tokens=10,
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -179,7 +179,7 @@ SST5_CONFIG = DatasetConfig(
         positive="positive", neutral="neutral", negative="negative"
     ),
     num_few_shot_examples=12,
-    max_generated_tokens=3,
+    max_generated_tokens=10,
 )
 
 # TODO: Icelandic Sentiment Classification

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -493,6 +493,7 @@ def generate_batch(
     # input if it is present
     inputs = inputs.detach().cpu()
     model_output.sequences = model_output.sequences.detach().cpu()
+    breakpoint()
     if torch.equal(model_output.sequences[:, : inputs.shape[1]], inputs):
         model_output.sequences = model_output.sequences[:, inputs.shape[1] :]
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -505,16 +505,6 @@ def generate_batch(
         input_batch=input_batch, model_output=model_output, tokenizer=tokenizer
     )
 
-    # TEMP
-    prompt = (
-        tokenizer.decode(batch["input_ids"][0].tolist())
-        .split("\n\n")[-1]
-        .split("\n")[0]
-        .lstrip("Text: ")
-    )
-    logger.info(f"Prompt: {prompt}")
-    logger.info(f"Generated label: {extracted_labels[0]}")
-
     return model_output, extracted_labels
 
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -505,6 +505,16 @@ def generate_batch(
         input_batch=input_batch, model_output=model_output, tokenizer=tokenizer
     )
 
+    # TEMP
+    prompt = (
+        tokenizer.decode(batch["input_ids"][0].tolist())
+        .split("\n\n")[-1]
+        .split("\n")[0]
+    )
+    breakpoint()
+    logger.info(f"Prompt: {prompt}")
+    logger.info(f"Generated labels: {extracted_labels}")
+
     return model_output, extracted_labels
 
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -505,6 +505,16 @@ def generate_batch(
         input_batch=input_batch, model_output=model_output, tokenizer=tokenizer
     )
 
+    # TEMP
+    prompt = (
+        tokenizer.decode(batch["input_ids"][0].tolist())
+        .split("\n\n")[-1]
+        .split("\n")[0]
+        .lstrip("Text: ")
+    )
+    logger.info(f"Prompt: {prompt}")
+    logger.info(f"Generated label: {extracted_labels[0]}")
+
     return model_output, extracted_labels
 
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -510,10 +510,10 @@ def generate_batch(
         tokenizer.decode(batch["input_ids"][0].tolist())
         .split("\n\n")[-1]
         .split("\n")[0]
+        .lstrip("Text: ")
     )
-    breakpoint()
     logger.info(f"Prompt: {prompt}")
-    logger.info(f"Generated labels: {extracted_labels}")
+    logger.info(f"Generated label: {extracted_labels[0]}")
 
     return model_output, extracted_labels
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -493,7 +493,6 @@ def generate_batch(
     # input if it is present
     inputs = inputs.detach().cpu()
     model_output.sequences = model_output.sequences.detach().cpu()
-    breakpoint()
     if torch.equal(model_output.sequences[:, : inputs.shape[1]], inputs):
         model_output.sequences = model_output.sequences[:, inputs.shape[1] :]
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -334,7 +334,6 @@ def generate_single_iteration(
         model_output = load_cached_model_outputs(
             cached_dataset=cached_dataset, cache=cache, tokenizer=tokenizer
         )
-        breakpoint()
         extracted_labels = extract_labels_fn(
             input_batch=cached_dataset, model_output=model_output, tokenizer=tokenizer
         )

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -506,14 +506,14 @@ def generate_batch(
     )
 
     # TEMP
-    prompt = (
-        tokenizer.decode(batch["input_ids"][0].tolist())
-        .split("\n\n")[-1]
-        .split("\n")[0]
-        .lstrip("Text: ")
-    )
-    logger.info(f"Prompt: {prompt}")
-    logger.info(f"Generated label: {extracted_labels[0]}")
+    # prompt = (
+    #     tokenizer.decode(batch["input_ids"][0].tolist())
+    #     .split("\n\n")[-1]
+    #     .split("\n")[0]
+    #     .lstrip("Text: ")
+    # )
+    # logger.info(f"Prompt: {prompt}")
+    # logger.info(f"Generated label: {extracted_labels[0]}")
 
     return model_output, extracted_labels
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -334,6 +334,7 @@ def generate_single_iteration(
         model_output = load_cached_model_outputs(
             cached_dataset=cached_dataset, cache=cache, tokenizer=tokenizer
         )
+        breakpoint()
         extracted_labels = extract_labels_fn(
             input_batch=cached_dataset, model_output=model_output, tokenizer=tokenizer
         )

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -323,9 +323,6 @@ def generate_single_iteration(
                 )
                 all_preds.extend(extracted_labels)
 
-                # TEMP
-                logger.info(f"Generated labels: {extracted_labels}")
-
         if isinstance(itr, tqdm):
             itr.close()
 

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -183,7 +183,6 @@ class ModelCache:
                     cached_model_output.vocab_size = int(scores.shape[-1])
 
                 # Store the generated sequence in the cache
-                breakpoint()
                 self[decoded_inputs] = cached_model_output
 
 
@@ -294,6 +293,7 @@ def load_cached_model_outputs(
         batch_first=True,
         padding_value=0.0,
     )
+    breakpoint()
     for batch_idx in range(cached_scores.shape[0]):
         for sequence_idx in range(cached_scores.shape[1]):
             top_indices = top_score_indices[batch_idx, sequence_idx]

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -142,6 +142,7 @@ class ModelCache:
         # Extract the scores from the model output, to be cached. We only store the
         # indices of the top scores, to save space. Further, we only store the scores
         # if the generated sequence is shorter than the maximum length
+        breakpoint()
         store_scores = "scores" in model_output and self.max_generated_tokens < 8
         if store_scores:
             scores = torch.stack(

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -142,7 +142,6 @@ class ModelCache:
         # Extract the scores from the model output, to be cached. We only store the
         # indices of the top scores, to save space. Further, we only store the scores
         # if the generated sequence is shorter than the maximum length
-        breakpoint()
         store_scores = "scores" in model_output and self.max_generated_tokens < 8
         if store_scores:
             scores = torch.stack(
@@ -184,6 +183,7 @@ class ModelCache:
                     cached_model_output.vocab_size = int(scores.shape[-1])
 
                 # Store the generated sequence in the cache
+                breakpoint()
                 self[decoded_inputs] = cached_model_output
 
 

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -295,9 +295,8 @@ def load_cached_model_outputs(
             for cached_model_output in cached_model_outputs
         ],
         batch_first=True,
-        padding_value=0.0,
+        padding_value=-math.inf,
     )
-    breakpoint()
     for batch_idx in range(cached_scores.shape[0]):
         for sequence_idx in range(cached_scores.shape[1]):
             top_indices = top_score_indices[batch_idx, sequence_idx]

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import sys
 from collections import defaultdict
 from dataclasses import asdict, dataclass
@@ -268,14 +269,17 @@ def load_cached_model_outputs(
     # Otherwise, we format the cached scores into a tensor of shape [batch_size,
     # num_sequences, vocab_size], wrap it in a ModelOutput with the padded cached
     # sequences, and return it
-    cached_scores = torch.zeros(
-        len(cached_model_outputs),
-        max(
-            len(cached_model_output.top_score_indices)
-            for cached_model_output in cached_model_outputs
-            if cached_model_output.top_score_indices is not None
+    cached_scores = torch.full(
+        size=(
+            len(cached_model_outputs),
+            max(
+                len(cached_model_output.top_score_indices)
+                for cached_model_output in cached_model_outputs
+                if cached_model_output.top_score_indices is not None
+            ),
+            cached_model_outputs[0].vocab_size,
         ),
-        cached_model_outputs[0].vocab_size,
+        fill_value=-math.inf,
     )
     top_score_indices = torch.nn.utils.rnn.pad_sequence(
         sequences=[

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -560,6 +560,9 @@ class OpenAIModel:
         if generation_config.return_dict_in_generate:
             output_dict = dict(sequences=output)
 
+            # TEMP
+            logger.info(f"Generated: {generation_output}")
+
             # Add logprobs scores to the output
             if generation_config.output_scores:
                 # Create a list with placeholder logprobs for every token generated.

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -585,11 +585,9 @@ class OpenAIModel:
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()
-                        try:
+                        if token:
                             token_idx = self.tokenizer.encode(text=token)[0]
-                        except IndexError:
-                            breakpoint()
-                        scores[gen_token_idx][0, token_idx] = logprob
+                            scores[gen_token_idx][0, token_idx] = logprob
 
                 output_dict["scores"] = tuple(scores)
 

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -555,6 +555,9 @@ class OpenAIModel:
                 f"The prompt causing it was {prompt!r}."
             )
 
+        # TEMP
+        logger.info(f"Generated text: {generation_output!r}")
+
         completion_ids = self.tokenizer([generation_output]).input_ids.tolist()
         output = LongTensor(completion_ids)
 

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -6,6 +6,7 @@ import math
 from typing import TYPE_CHECKING, Literal
 
 import torch
+from openai.types.chat.chat_completion_token_logprob import TopLogprob
 from torch import LongTensor
 from torch.nn.utils.rnn import pad_sequence
 from transformers import BatchEncoding, GenerationConfig
@@ -581,6 +582,13 @@ class OpenAIModel:
                     logger.info(
                         f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
                     )
+
+                    top_logprobs: list[TopLogprob] = list()
+                    for logprob_obj in logprobs.top_logprobs:
+                        token = logprob_obj.token.strip()
+                        if token in {lg.token.strip() for lg in top_logprobs}:
+                            continue
+                        top_logprobs.append(logprob_obj)
 
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -557,7 +557,7 @@ class OpenAIModel:
             )
 
         # TEMP
-        logger.info(f"Generated text: {generation_output!r}")
+        # logger.info(f"Generated text: {generation_output!r}")
 
         completion_ids = self.tokenizer([generation_output]).input_ids.tolist()
         output = LongTensor(completion_ids)
@@ -583,9 +583,9 @@ class OpenAIModel:
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
                     # TEMP
-                    logger.info(
-                        f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
-                    )
+                    # logger.info(
+                    #     f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
+                    # )
 
                     # Remove duplicate logprobs, since, e.g., "negative" and " negative"
                     # can both be included in the list, and we only want the one with

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -560,9 +560,6 @@ class OpenAIModel:
         if generation_config.return_dict_in_generate:
             output_dict = dict(sequences=output)
 
-            # TEMP
-            logger.info(f"Generated: {generation_output!r}")
-
             # Add logprobs scores to the output
             if generation_config.output_scores:
                 # Create a list with placeholder logprobs for every token generated.
@@ -580,6 +577,11 @@ class OpenAIModel:
                 # OpenAI output only contain the logprobs for the top-k tokens, so we
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
+                    # TEMP
+                    logger.info(
+                        f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
+                    )
+
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -583,6 +583,9 @@ class OpenAIModel:
                         f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
                     )
 
+                    # Remove duplicate logprobs, since, e.g., "negative" and " negative"
+                    # can both be included in the list, and we only want the one with
+                    # the highest logprob
                     top_logprobs: list[TopLogprob] = list()
                     for logprob_obj in logprobs.top_logprobs:
                         token = logprob_obj.token.strip()
@@ -590,11 +593,9 @@ class OpenAIModel:
                             continue
                         top_logprobs.append(logprob_obj)
 
-                    for logprob_obj in logprobs.top_logprobs:
+                    for logprob_obj in top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()
-                        logger.info(f"Token: {token}")
-                        breakpoint()
                         if token:
                             token_idx = self.tokenizer.encode(text=token)[0]
                             scores[gen_token_idx][0, token_idx] = logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -560,6 +560,9 @@ class OpenAIModel:
         if generation_config.return_dict_in_generate:
             output_dict = dict(sequences=output)
 
+            # TEMP
+            logger.info(f"Generated: {generation_output!r}")
+
             # Add logprobs scores to the output
             if generation_config.output_scores:
                 # Create a list with placeholder logprobs for every token generated.

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -578,11 +578,6 @@ class OpenAIModel:
                 # OpenAI output only contain the logprobs for the top-k tokens, so we
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
-                    # TEMP
-                    logger.info(
-                        f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
-                    )
-
                     # Remove duplicate logprobs, since, e.g., "negative" and " negative"
                     # can both be included in the list, and we only want the one with
                     # the highest logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -577,11 +577,6 @@ class OpenAIModel:
                 # OpenAI output only contain the logprobs for the top-k tokens, so we
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
-                    # TEMP
-                    logger.info(
-                        f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
-                    )
-
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -556,9 +556,6 @@ class OpenAIModel:
                 f"The prompt causing it was {prompt!r}."
             )
 
-        # TEMP
-        # logger.info(f"Generated text: {generation_output!r}")
-
         completion_ids = self.tokenizer([generation_output]).input_ids.tolist()
         output = LongTensor(completion_ids)
 
@@ -582,11 +579,6 @@ class OpenAIModel:
                 # OpenAI output only contain the logprobs for the top-k tokens, so we
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
-                    # TEMP
-                    # logger.info(
-                    #     f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
-                    # )
-
                     # Remove duplicate logprobs, since, e.g., "negative" and " negative"
                     # can both be included in the list, and we only want the one with
                     # the highest logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -525,6 +525,7 @@ class OpenAIModel:
             n=generation_config.num_return_sequences,
             frequency_penalty=generation_config.repetition_penalty - 1.0,
             stop=["\n\n", self.tokenizer.eos_token, self.tokenizer.pad_token],
+            seed=4242,
         )
 
         if generation_config.output_scores:

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -581,11 +581,12 @@ class OpenAIModel:
                     logger.info(
                         f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
                     )
-                    breakpoint()
 
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()
+                        logger.info(f"Token: {token}")
+                        breakpoint()
                         if token:
                             token_idx = self.tokenizer.encode(text=token)[0]
                             scores[gen_token_idx][0, token_idx] = logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -585,7 +585,10 @@ class OpenAIModel:
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob
                         token = logprob_obj.token.strip()
-                        token_idx = self.tokenizer.encode(text=token)[0]
+                        try:
+                            token_idx = self.tokenizer.encode(text=token)[0]
+                        except IndexError:
+                            breakpoint()
                         scores[gen_token_idx][0, token_idx] = logprob
 
                 output_dict["scores"] = tuple(scores)

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -561,7 +561,7 @@ class OpenAIModel:
             output_dict = dict(sequences=output)
 
             # TEMP
-            logger.info(f"Generated: {generation_output}")
+            logger.info(f"Generated: {generation_output!r}")
 
             # Add logprobs scores to the output
             if generation_config.output_scores:

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -547,7 +547,7 @@ class OpenAIModel:
                 generation_output = model_output.choices[0].text.strip()
             else:
                 model_output = self.client.chat.completions.create(
-                    messages=[dict(role="user", content=prompt)], **generation_kwargs
+                    messages=[dict(role="system", content=prompt)], **generation_kwargs
                 )
                 generation_output = model_output.choices[0].message.content.strip()
         except BadRequestError as e:

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -581,6 +581,7 @@ class OpenAIModel:
                     logger.info(
                         f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
                     )
+                    breakpoint()
 
                     for logprob_obj in logprobs.top_logprobs:
                         logprob = logprob_obj.logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -558,7 +558,6 @@ class OpenAIModel:
 
         # TEMP
         logger.info(f"Generated text: {generation_output!r}")
-        breakpoint()
 
         completion_ids = self.tokenizer([generation_output]).input_ids.tolist()
         output = LongTensor(completion_ids)

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -578,6 +578,11 @@ class OpenAIModel:
                 # OpenAI output only contain the logprobs for the top-k tokens, so we
                 # only fill in these and leave the rest at ~0% probability
                 for gen_token_idx, logprobs in enumerate(logprobs_list):
+                    # TEMP
+                    logger.info(
+                        f"Top tokens: {[lg.token for lg in logprobs.top_logprobs]}"
+                    )
+
                     # Remove duplicate logprobs, since, e.g., "negative" and " negative"
                     # can both be included in the list, and we only want the one with
                     # the highest logprob

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -560,9 +560,6 @@ class OpenAIModel:
         if generation_config.return_dict_in_generate:
             output_dict = dict(sequences=output)
 
-            # TEMP
-            logger.info(f"Generated: {generation_output!r}")
-
             # Add logprobs scores to the output
             if generation_config.output_scores:
                 # Create a list with placeholder logprobs for every token generated.

--- a/src/scandeval/openai_models.py
+++ b/src/scandeval/openai_models.py
@@ -558,6 +558,7 @@ class OpenAIModel:
 
         # TEMP
         logger.info(f"Generated text: {generation_output!r}")
+        breakpoint()
 
         completion_ids = self.tokenizer([generation_output]).input_ids.tolist()
         output = LongTensor(completion_ids)

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -388,7 +388,7 @@ def get_closest_logprobs_labels(
     predicted_labels = [candidate_labels[idx] for idx in predicted_label_ids]
 
     # TEMP
-    logger.info(f"Predicted labels: {predicted_labels}")
+    # logger.info(f"Predicted labels: {predicted_labels}")
 
     return predicted_labels
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -387,9 +387,6 @@ def get_closest_logprobs_labels(
 
     predicted_labels = [candidate_labels[idx] for idx in predicted_label_ids]
 
-    # TEMP
-    # logger.info(f"Predicted labels: {predicted_labels}")
-
     return predicted_labels
 
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -381,8 +381,6 @@ def get_closest_logprobs_labels(
         )["input_ids"]
         candidate_label_id: int = candidate_label_ids[0][0]
         pred_logprobs[:, idx] = generation_logprobs[:, 0, candidate_label_id]
-        breakpoint()
-        pass
 
     # Shape: [batch_size,]
     predicted_label_ids = pred_logprobs.argmax(dim=1)

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -382,8 +382,6 @@ def get_closest_logprobs_labels(
         candidate_label_id: int = candidate_label_ids[0][0]
         pred_logprobs[:, idx] = generation_logprobs[:, 0, candidate_label_id]
 
-    breakpoint()
-
     # Shape: [batch_size,]
     predicted_label_ids = pred_logprobs.argmax(dim=1)
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -369,7 +369,6 @@ def get_closest_logprobs_labels(
         len(candidate_labels),
         device=generation_logprobs.device,
     )
-    breakpoint()
 
     for idx, candidate_label in enumerate(candidate_labels):
         # We only use the first token to represent the logprob value of the entire
@@ -386,7 +385,12 @@ def get_closest_logprobs_labels(
     # Shape: [batch_size,]
     predicted_label_ids = pred_logprobs.argmax(dim=1)
 
-    return [candidate_labels[idx] for idx in predicted_label_ids]
+    predicted_labels = [candidate_labels[idx] for idx in predicted_label_ids]
+
+    # TEMP
+    logger.info(f"Predicted labels: {predicted_labels}")
+
+    return predicted_labels
 
 
 def get_closest_word_edit_labels(

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -389,6 +389,7 @@ def get_closest_logprobs_labels(
 
     # TEMP
     logger.info(f"Predicted labels: {predicted_labels}")
+    breakpoint()
 
     return predicted_labels
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -311,6 +311,7 @@ class SequenceClassification(BenchmarkDataset):
         Returns:
             The predicted labels.
         """
+        breakpoint()
         if "scores" in model_output:
             if isinstance(model_output["scores"], tuple):
                 all_logprobs = torch.stack(model_output["scores"], dim=1)

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -382,6 +382,8 @@ def get_closest_logprobs_labels(
         candidate_label_id: int = candidate_label_ids[0][0]
         pred_logprobs[:, idx] = generation_logprobs[:, 0, candidate_label_id]
 
+    breakpoint()
+
     # Shape: [batch_size,]
     predicted_label_ids = pred_logprobs.argmax(dim=1)
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -311,7 +311,6 @@ class SequenceClassification(BenchmarkDataset):
         Returns:
             The predicted labels.
         """
-        breakpoint()
         if "scores" in model_output:
             if isinstance(model_output["scores"], tuple):
                 all_logprobs = torch.stack(model_output["scores"], dim=1)
@@ -390,6 +389,7 @@ def get_closest_logprobs_labels(
 
     # TEMP
     logger.info(f"Predicted labels: {predicted_labels}")
+    breakpoint()
 
     return predicted_labels
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -389,7 +389,6 @@ def get_closest_logprobs_labels(
 
     # TEMP
     logger.info(f"Predicted labels: {predicted_labels}")
-    breakpoint()
 
     return predicted_labels
 

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -186,6 +186,10 @@ class SequenceClassification(BenchmarkDataset):
             for label in labels
         ]
 
+        # TEMP
+        logger.info(f"Predictions: {predictions}")
+        logger.info(f"Labels: {labels}")
+
         results: dict[str, float] = dict()
         for cfg in self.dataset_config.task.metrics:
             metric = self._metrics[cfg.name]

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -186,10 +186,6 @@ class SequenceClassification(BenchmarkDataset):
             for label in labels
         ]
 
-        # TEMP
-        logger.info(f"Predictions: {predictions}")
-        logger.info(f"Labels: {labels}")
-
         results: dict[str, float] = dict()
         for cfg in self.dataset_config.task.metrics:
             metric = self._metrics[cfg.name]

--- a/src/scandeval/sequence_classification.py
+++ b/src/scandeval/sequence_classification.py
@@ -369,6 +369,7 @@ def get_closest_logprobs_labels(
         len(candidate_labels),
         device=generation_logprobs.device,
     )
+    breakpoint()
 
     for idx, candidate_label in enumerate(candidate_labels):
         # We only use the first token to represent the logprob value of the entire

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -624,6 +624,9 @@ def should_prompts_be_stripped(
     Returns:
         Whether we should strip the prompts.
     """
+    if isinstance(tokenizer, OpenAITokenizer):
+        return False
+
     strip_prompts = True
     for label in labels_to_be_generated:
         colon_tokens = tokenizer(": ", add_special_tokens=False).input_ids
@@ -659,9 +662,6 @@ def should_prefix_space_be_added_to_labels(
     Returns:
         Whether we should add a prefix space to the labels.
     """
-    if isinstance(tokenizer, OpenAITokenizer):
-        return False
-
     if not should_prompts_be_stripped(
         labels_to_be_generated=labels_to_be_generated, tokenizer=tokenizer
     ):

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -624,9 +624,6 @@ def should_prompts_be_stripped(
     Returns:
         Whether we should strip the prompts.
     """
-    if isinstance(tokenizer, OpenAITokenizer):
-        return False
-
     strip_prompts = True
     for label in labels_to_be_generated:
         colon_tokens = tokenizer(": ", add_special_tokens=False).input_ids
@@ -662,6 +659,9 @@ def should_prefix_space_be_added_to_labels(
     Returns:
         Whether we should add a prefix space to the labels.
     """
+    if isinstance(tokenizer, OpenAITokenizer):
+        return False
+
     if not should_prompts_be_stripped(
         labels_to_be_generated=labels_to_be_generated, tokenizer=tokenizer
     ):

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -659,6 +659,8 @@ def should_prefix_space_be_added_to_labels(
     Returns:
         Whether we should add a prefix space to the labels.
     """
+    # We don't add a prefix space to OpenAI models, since they output strings directly,
+    # and we always strip these for token ID consistency
     if isinstance(tokenizer, OpenAITokenizer):
         return False
 

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -639,9 +639,6 @@ def should_prompts_be_stripped(
         if label_tokens_start_with_colon_tokens:
             strip_prompts = False
 
-    # TEMP
-    logger.info(f"{ strip_prompts = }")
-
     return strip_prompts
 
 
@@ -685,9 +682,6 @@ def should_prefix_space_be_added_to_labels(
         if has_prefix_space:
             add_prefix_space = False
             break
-
-    # TEMP
-    logger.info(f"{ add_prefix_space = }")
 
     return add_prefix_space
 

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -641,7 +641,7 @@ def should_prompts_be_stripped(
             strip_prompts = False
 
     # TEMP
-    logger.debug(f"{ strip_prompts = }")
+    logger.info(f"{ strip_prompts = }")
     breakpoint()
 
     return strip_prompts

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -642,6 +642,7 @@ def should_prompts_be_stripped(
 
     # TEMP
     logger.debug(f"{ strip_prompts = }")
+    breakpoint()
 
     return strip_prompts
 

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -28,6 +28,7 @@ from transformers import logging as tf_logging
 from .enums import Framework
 from .exceptions import NaNValueInModelOutput
 from .languages import DA, NB, NN, NO, SV, get_all_languages
+from .openai_models import OpenAITokenizer
 
 if TYPE_CHECKING:
     from huggingface_hub.hf_api import ModelInfo
@@ -661,6 +662,9 @@ def should_prefix_space_be_added_to_labels(
     Returns:
         Whether we should add a prefix space to the labels.
     """
+    if isinstance(tokenizer, OpenAITokenizer):
+        return False
+
     if not should_prompts_be_stripped(
         labels_to_be_generated=labels_to_be_generated, tokenizer=tokenizer
     ):

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -624,9 +624,6 @@ def should_prompts_be_stripped(
     Returns:
         Whether we should strip the prompts.
     """
-    if isinstance(tokenizer, OpenAITokenizer):
-        return False
-
     strip_prompts = True
     for label in labels_to_be_generated:
         colon_tokens = tokenizer(": ", add_special_tokens=False).input_ids
@@ -642,6 +639,10 @@ def should_prompts_be_stripped(
         )
         if label_tokens_start_with_colon_tokens:
             strip_prompts = False
+
+    # TEMP
+    logger.debug(f"{ strip_prompts = }")
+
     return strip_prompts
 
 
@@ -662,6 +663,9 @@ def should_prefix_space_be_added_to_labels(
     Returns:
         Whether we should add a prefix space to the labels.
     """
+    if isinstance(tokenizer, OpenAITokenizer):
+        return False
+
     if not should_prompts_be_stripped(
         labels_to_be_generated=labels_to_be_generated, tokenizer=tokenizer
     ):

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,5 +1,7 @@
 """Unit tests for the `model_loading` module."""
 
+import os
+
 import pytest
 from scandeval.config import ModelConfig
 from scandeval.enums import Framework
@@ -23,6 +25,7 @@ def test_load_non_generative_model(model_id, dataset_config, benchmark_config):
     assert model is not None
 
 
+@pytest.mark.skipif(condition=os.getenv("USE_VLLM", "0") != "1")
 def test_load_generative_model(generative_model_and_tokenizer):
     """Test loading a generative model."""
     model, tokenizer = generative_model_and_tokenizer

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -25,7 +25,9 @@ def test_load_non_generative_model(model_id, dataset_config, benchmark_config):
     assert model is not None
 
 
-@pytest.mark.skipif(condition=os.getenv("USE_VLLM", "0") != "1")
+@pytest.mark.skipif(
+    condition=os.getenv("USE_VLLM", "0") != "1", reason="Not using VLLM."
+)
 def test_load_generative_model(generative_model_and_tokenizer):
     """Test loading a generative model."""
     model, tokenizer = generative_model_and_tokenizer


### PR DESCRIPTION
### Fixed
- Correctly update logits processors and prefix allowed functions tokens functions for
  NER datasets when starting generation.
- We now use logprobs for OpenAI models, as this is supported by the chat models now.
  This is used for all sequence classification based tasks, which currently comprise of
  sentiment classification, linguistic acceptability, knowledge and common-sense
  reasoning. This fixes some incorrect evaluations of the newer GPT-4-turbo and GPT-4o
  models, as they tend to output things like "Sentiment: positive" rather than simply
  "positive".