### PR TITLE
Feat/501 add belebele

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added the Belebele dataset, being a multilingual multiple-choice reading comprehension
+  dataset. This has been added as a separate `multiple-choice-reading-comprehension`
+  task, and is available in all supported languages except Faroese. The dataset has been
+  marked as unofficial, meaning that it will not be automatically included when
+  benchmarking models, but can be included by specifying the dataset explicitly using
+  the `--dataset` argument (or `dataset` argument if using the `Benchmarker` API).
+
 ### Fixed
 - Update `vllm` to `>=0.5.2` and `transformers` to `>=4.42.4`, which now allows
   evaluation of Gemma 2 models.
@@ -16,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Added `gpt-4o-mini` metadata, to correctly display maximum sequence length and
   vocabulary size.
+- Changed the name of the `question-answering` task to the more descriptive name
+  `reading-comprehension`.
 
 
 ## [v12.11.0] - 2024-07-03

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -2,7 +2,7 @@
 
 from .config import DatasetConfig
 from .languages import DA, DE, EN, FO, IS, NB, NL, NN, NO, SV, get_all_languages
-from .tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SPEED, SUMM
+from .tasks import COMMON_SENSE, KNOW, LA, MCRC, NER, RC, SENT, SPEED, SUMM
 
 
 def get_all_dataset_configs() -> dict[str, DatasetConfig]:
@@ -577,14 +577,14 @@ SCALA_EN_CONFIG = DatasetConfig(
 )
 
 
-### EXTRACTIVE QUESTION ANSWERING DATASETS ###
+### READING COMPREHENSION DATASETS ###
 
 SCANDIQA_DA_CONFIG = DatasetConfig(
     name="scandiqa-da",
     pretty_name="the Danish part of the truncated version of the question answering "
     "dataset ScandiQA",
     huggingface_id="ScandEval/scandiqa-da-mini",
-    task=QA,
+    task=RC,
     languages=[DA],
     prompt_prefix="Følgende er tekster med tilhørende spørgsmål og svar.",
     prompt_template="Tekst: {text}\nSpørgsmål: {question}\nSvar med maks. 3 ord: "
@@ -598,7 +598,7 @@ NORQUAD_CONFIG = DatasetConfig(
     pretty_name="the truncated version of the Norwegian question answering "
     "dataset NorQuAD",
     huggingface_id="ScandEval/norquad-mini",
-    task=QA,
+    task=RC,
     languages=[NB, NN, NO],
     prompt_prefix="Her følger tekster med tilhørende spørsmål og svar.",
     prompt_template="Tekst: {text}\nSpørsmål: {question}\nSvar på maks 3 ord: {label}",
@@ -611,7 +611,7 @@ SCANDIQA_SV_CONFIG = DatasetConfig(
     pretty_name="the Swedish part of the truncated version of the question answering "
     "dataset ScandiQA",
     huggingface_id="ScandEval/scandiqa-sv-mini",
-    task=QA,
+    task=RC,
     languages=[SV],
     prompt_prefix="Nedan följer texter med tillhörande frågor och svar.",
     prompt_template="Text: {text}\nFråga: {question}\nSvar på max 3 ord: {label}",
@@ -624,7 +624,7 @@ NQII_CONFIG = DatasetConfig(
     pretty_name="the truncated version of the Icelandic question answering dataset "
     "Natural Questions in Icelandic",
     huggingface_id="ScandEval/nqii-mini",
-    task=QA,
+    task=RC,
     languages=[IS],
     prompt_prefix="Eftirfarandi eru textar með tilheyrandi spurningum og svörum.",
     prompt_template="Texti: {text}\nSpurning: {question}\nSvaraðu með að hámarki 3 "
@@ -637,7 +637,7 @@ NQII_CONFIG = DatasetConfig(
 #     name="foqa",
 #     pretty_name="Faroese Question Answering",
 #     huggingface_id="ScandEval/foqa-mini",  # TODO: Needs to be uploaded
-#     task=QA,
+#     task=RC,
 #     languages=[FO],
 #     prompt_template="{text}\nSpurningur: {question}\nSvara við í mesta lagi trimum "
 #     "orðum: {label}",
@@ -650,7 +650,7 @@ GERMANQUAD_CONFIG = DatasetConfig(
     pretty_name="the truncated version of the German question answering dataset "
     "GermanQuAD",
     huggingface_id="ScandEval/germanquad-mini",
-    task=QA,
+    task=RC,
     languages=[DE],
     prompt_prefix="Im Folgenden finden Sie Texte mit den dazugehörigen Fragen und "
     "Antworten.",
@@ -665,7 +665,7 @@ SQUAD_CONFIG = DatasetConfig(
     pretty_name="the truncated version of the English question answering "
     "dataset SQuAD",
     huggingface_id="ScandEval/squad-mini",
-    task=QA,
+    task=RC,
     languages=[EN],
     prompt_prefix="The following are texts with accompanying questions and answers.",
     prompt_template="Text: {text}\nQuestion: {question}\nAnswer in max 3 words: "
@@ -679,7 +679,7 @@ SQUAD_NL_CONFIG = DatasetConfig(
     pretty_name="the truncated version of the Dutch question answering dataset "
     "SQuAD-nl, translated from the English SQuAD dataset",
     huggingface_id="ScandEval/squad-nl-mini",
-    task=QA,
+    task=RC,
     languages=[NL],
     prompt_prefix="Hieronder volgen teksten met bijbehorende vragen en antwoorden.",
     prompt_template="Tekst: {text}\nVraag: {question}\nAntwoord in max 3 woorden: "
@@ -1136,6 +1136,117 @@ HELLASWAG_CONFIG = DatasetConfig(
 )
 
 # TODO: Faroese common sense reasoning
+
+
+### MULTIPLE CHOICE READING COMPREHENSION DATASETS ###
+
+BELEBELE_DA_CONFIG = DatasetConfig(
+    name="belebele-da",
+    pretty_name="the Danish multiple choice reading comprehension dataset BeleBele-da, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-da-mini",
+    task=MCRC,
+    languages=[DA],
+    prompt_prefix="Følgende er tekster med tilhørende multiple choice spørgsmål og svar.",
+    prompt_template="{text}\nSvar: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_SV_CONFIG = DatasetConfig(
+    name="belebele-sv",
+    pretty_name="the Swedish multiple choice reading comprehension dataset BeleBele-sv, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-sv-mini",
+    task=MCRC,
+    languages=[SV],
+    prompt_prefix="Nedan följer texter med tillhörande multiple choice frågor och svar.",
+    prompt_template="{text}\nSvar: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_NO_CONFIG = DatasetConfig(
+    name="belebele-no",
+    pretty_name="the Norwegian multiple choice reading comprehension dataset BeleBele-no, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-no-mini",
+    task=MCRC,
+    languages=[NB, NN, NO],
+    prompt_prefix="Her følger tekster med tilhørende multiple choice spørsmål og svar.",
+    prompt_template="{text}\nSvar: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_IS_CONFIG = DatasetConfig(
+    name="belebele-is",
+    pretty_name="the Icelandic multiple choice reading comprehension dataset BeleBele-is, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-is-mini",
+    task=MCRC,
+    languages=[IS],
+    prompt_prefix="Eftirfarandi eru textar með tilheyrandi fjölvalsspurningum og "
+    "svörum.",
+    prompt_template="{text}\nSvara: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_DE_CONFIG = DatasetConfig(
+    name="belebele-de",
+    pretty_name="the German multiple choice reading comprehension dataset BeleBele-de, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-de-mini",
+    task=MCRC,
+    languages=[DE],
+    prompt_prefix="Die folgenden Texte sind mit dazugehörigen Multiple-Choice-Fragen "
+    "und Antworten.",
+    prompt_template="{text}\nAntwort: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_NL_CONFIG = DatasetConfig(
+    name="belebele-nl",
+    pretty_name="the Dutch multiple choice reading comprehension dataset BeleBele-nl, "
+    "translated from the English BeleBele dataset",
+    huggingface_id="ScandEval/belebele-nl-mini",
+    task=MCRC,
+    languages=[NL],
+    prompt_prefix="Hieronder staan teksten met bijbehorende multiple choice vragen en "
+    "antwoorden.",
+    prompt_template="{text}\nAntwoord: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
+
+BELEBELE_CONFIG = DatasetConfig(
+    name="belebele",
+    pretty_name="the English multiple choice reading comprehension dataset BeleBele",
+    huggingface_id="ScandEval/belebele-mini",
+    task=MCRC,
+    languages=[EN],
+    prompt_prefix="The following are texts with accompanying multiple choice questions "
+    "and answers.",
+    prompt_template="{text}\nAnswer: {label}",
+    prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
+    num_few_shot_examples=5,
+    max_generated_tokens=1,
+    unofficial=True,
+)
 
 
 ### SPEED ESTIMATION DATASETS ###

--- a/src/scandeval/tasks.py
+++ b/src/scandeval/tasks.py
@@ -65,8 +65,8 @@ NER = Task(
 )
 
 
-QA = Task(
-    name="question-answering",
+RC = Task(
+    name="reading-comprehension",
     supertask="question-answering",
     metrics=[
         MetricConfig(
@@ -136,6 +136,27 @@ SUMM = Task(
 
 KNOW = Task(
     name="knowledge",
+    supertask="sequence-classification",
+    metrics=[
+        MetricConfig(
+            name="mcc",
+            pretty_name="Matthew's Correlation Coefficient",
+            huggingface_id="matthews_correlation",
+            results_key="matthews_correlation",
+        ),
+        MetricConfig(
+            name="accuracy",
+            pretty_name="Accuracy",
+            huggingface_id="accuracy",
+            results_key="accuracy",
+        ),
+    ],
+    labels=["a", "b", "c", "d"],
+)
+
+
+MCRC = Task(
+    name="multiple-choice-reading-comprehension",
     supertask="sequence-classification",
     metrics=[
         MetricConfig(

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -56,7 +56,11 @@ GENERATIVE_MODEL_TASKS = [
 ]
 
 
-GENERATIVE_DATASET_TASKS = ["knowledge", "common-sense-reasoning"]
+GENERATIVE_DATASET_TASKS = [
+    "knowledge",
+    "common-sense-reasoning",
+    "multiple-choice-reading-comprehension",
+]
 
 
 GENERATIVE_DATASET_SUPERTASKS = ["text-to-text", "text-modelling"]

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -143,7 +143,7 @@ def main() -> None:
         df.reset_index(drop=True, inplace=True)
 
         # Create validation split
-        val_size = 64
+        val_size = 128
         traintest_arr, val_arr = train_test_split(
             df, test_size=val_size, random_state=4242
         )
@@ -151,16 +151,12 @@ def main() -> None:
         val_df = pd.DataFrame(val_arr, columns=df.columns)
 
         # Create test split
-        test_size = 512
+        train_size = 64
         train_arr, test_arr = train_test_split(
-            traintest_df, test_size=test_size, random_state=4242
+            traintest_df, train_size=train_size, random_state=4242
         )
         train_df = pd.DataFrame(train_arr, columns=df.columns)
         test_df = pd.DataFrame(test_arr, columns=df.columns)
-
-        # Create train split
-        train_size = 256
-        train_df = train_df.sample(train_size, random_state=4242)
 
         # Reset the index
         train_df = train_df.reset_index(drop=True)

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -1,0 +1,195 @@
+"""Create the Belebele-mini datasets and upload them to the HF Hub."""
+
+import re
+from collections import Counter
+
+import pandas as pd
+from constants import (
+    MAX_NUM_CHARS_IN_INSTRUCTION,
+    MAX_NUM_CHARS_IN_OPTION,
+    MAX_REPETITIONS,
+    MIN_NUM_CHARS_IN_INSTRUCTION,
+    MIN_NUM_CHARS_IN_OPTION,
+)
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+from sklearn.model_selection import train_test_split
+
+
+def main() -> None:
+    """Create the Belebele-mini datasets and upload them to the HF Hub."""
+    repo_id = "facebook/belebele"
+
+    language_mapping = {
+        "da": "dan_Latn",
+        "no": "nob_Latn",
+        "sv": "swe_Latn",
+        "is": "isl_Latn",
+        "de": "deu_Latn",
+        "nl": "nld_Latn",
+        "en": "eng_Latn",
+    }
+    text_mapping = {
+        "da": "Tekst",
+        "no": "Tekst",
+        "sv": "Text",
+        "is": "Texti",
+        "de": "Text",
+        "nl": "Tekst",
+        "en": "Text",
+    }
+    question_mapping = {
+        "da": "Spørgsmål",
+        "no": "Spørsmål",
+        "sv": "Fråga",
+        "is": "Spurning",
+        "de": "Fragen",
+        "nl": "Vraag",
+        "en": "Question",
+    }
+    choices_mapping = {
+        "da": "Svarmuligheder",
+        "no": "Svaralternativer",
+        "sv": "Svarsalternativ",
+        "is": "Svarmöguleikar",
+        "de": "Antwortmöglichkeiten",
+        "nl": "Antwoordopties",
+        "en": "Choices",
+    }
+
+    for language in choices_mapping.keys():
+        # Download the dataset
+        dataset = load_dataset(
+            path=repo_id, split=language_mapping[language], token=True
+        )
+        assert isinstance(dataset, Dataset)
+
+        # Convert the dataset to a dataframe
+        df = dataset.to_pandas()
+        assert isinstance(df, pd.DataFrame)
+
+        # Rename the columns
+        df.rename(
+            columns=dict(
+                correct_answer_num="label",
+                mc_answer1="option_a",
+                mc_answer2="option_b",
+                mc_answer3="option_c",
+                mc_answer4="option_d",
+            ),
+            inplace=True,
+        )
+
+        # Convert the label to letters
+        label_mapping = {1: "a", 2: "b", 3: "c", 4: "d"}
+        df.label = df.label.map(label_mapping)
+
+        # Create the instruction from the passage and question
+        df["instruction"] = (
+            text_mapping[language]
+            + ": "
+            + df.flores_passage
+            + "\n"
+            + question_mapping[language]
+            + ": "
+            + df.question
+        )
+
+        # Remove the samples with overly short or long texts
+        df = df[
+            (df.instruction.str.len() >= MIN_NUM_CHARS_IN_INSTRUCTION)
+            & (df.instruction.str.len() <= MAX_NUM_CHARS_IN_INSTRUCTION)
+            & (df.option_a.str.len() >= MIN_NUM_CHARS_IN_OPTION)
+            & (df.option_a.str.len() <= MAX_NUM_CHARS_IN_OPTION)
+            & (df.option_b.str.len() >= MIN_NUM_CHARS_IN_OPTION)
+            & (df.option_b.str.len() <= MAX_NUM_CHARS_IN_OPTION)
+            & (df.option_c.str.len() >= MIN_NUM_CHARS_IN_OPTION)
+            & (df.option_c.str.len() <= MAX_NUM_CHARS_IN_OPTION)
+            & (df.option_d.str.len() >= MIN_NUM_CHARS_IN_OPTION)
+            & (df.option_d.str.len() <= MAX_NUM_CHARS_IN_OPTION)
+        ]
+
+        def is_repetitive(text: str) -> bool:
+            """Return True if the text is repetitive."""
+            max_repetitions = max(Counter(text.split()).values())
+            return max_repetitions > MAX_REPETITIONS
+
+        # Remove overly repetitive samples
+        df = df[
+            ~df.instruction.apply(is_repetitive)
+            & ~df.option_a.apply(is_repetitive)
+            & ~df.option_b.apply(is_repetitive)
+            & ~df.option_c.apply(is_repetitive)
+            & ~df.option_d.apply(is_repetitive)
+        ]
+
+        # Make a `text` column with all the options in it
+        df["text"] = [
+            re.sub(r"\n+", "\n", row.instruction).strip() + "\n"
+            f"{choices_mapping[language]}:\n"
+            "a. " + re.sub(r"\n+", "\n", row.option_a).strip() + "\n"
+            "b. " + re.sub(r"\n+", "\n", row.option_b).strip() + "\n"
+            "c. " + re.sub(r"\n+", "\n", row.option_c).strip() + "\n"
+            "d. " + re.sub(r"\n+", "\n", row.option_d).strip()
+            for _, row in df.iterrows()
+        ]
+
+        # Only keep the `text` and `label` columns
+        df = df[["text", "label"]]
+
+        # Remove duplicates
+        df.drop_duplicates(inplace=True)
+        df.reset_index(drop=True, inplace=True)
+
+        # Create validation split
+        val_size = 64
+        traintest_arr, val_arr = train_test_split(
+            df, test_size=val_size, random_state=4242
+        )
+        traintest_df = pd.DataFrame(traintest_arr, columns=df.columns)
+        val_df = pd.DataFrame(val_arr, columns=df.columns)
+
+        # Create test split
+        test_size = 512
+        train_arr, test_arr = train_test_split(
+            traintest_df, test_size=test_size, random_state=4242
+        )
+        train_df = pd.DataFrame(train_arr, columns=df.columns)
+        test_df = pd.DataFrame(test_arr, columns=df.columns)
+
+        # Create train split
+        train_size = 256
+        train_df = train_df.sample(train_size, random_state=4242)
+
+        # Reset the index
+        train_df = train_df.reset_index(drop=True)
+        val_df = val_df.reset_index(drop=True)
+        test_df = test_df.reset_index(drop=True)
+
+        # Collect datasets in a dataset dictionary
+        dataset = DatasetDict(
+            train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+            val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+            test=Dataset.from_pandas(test_df, split=Split.TEST),
+        )
+
+        # Create dataset ID
+        if language == "en":
+            dataset_id = "ScandEval/belebele-mini"
+        else:
+            dataset_id = f"ScandEval/belebele-{language}-mini"
+
+        # Remove the dataset from Hugging Face Hub if it already exists
+        try:
+            api = HfApi()
+            api.delete_repo(dataset_id, repo_type="dataset")
+        except HTTPError:
+            pass
+
+        # Push the dataset to the Hugging Face Hub
+        dataset.push_to_hub(dataset_id, private=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_belebele.py
+++ b/src/scripts/create_belebele.py
@@ -82,7 +82,7 @@ def main() -> None:
         )
 
         # Convert the label to letters
-        label_mapping = {1: "a", 2: "b", 3: "c", 4: "d"}
+        label_mapping = {"1": "a", "2": "b", "3": "c", "4": "d"}
         df.label = df.label.map(label_mapping)
 
         # Create the instruction from the passage and question

--- a/tests/test_dataset_factory.py
+++ b/tests/test_dataset_factory.py
@@ -8,7 +8,7 @@ from scandeval.dataset_factory import DatasetFactory
 from scandeval.named_entity_recognition import NamedEntityRecognition
 from scandeval.question_answering import QuestionAnswering
 from scandeval.sequence_classification import SequenceClassification
-from scandeval.tasks import COMMON_SENSE, KNOW, LA, NER, QA, SENT, SUMM
+from scandeval.tasks import COMMON_SENSE, KNOW, LA, MCRC, NER, RC, SENT, SUMM
 from scandeval.text_to_text import TextToText
 
 
@@ -55,9 +55,9 @@ def test_build_ner_dataset(dataset_factory, dataset_config):
 
 
 def test_build_qa_dataset(dataset_factory, dataset_config):
-    """Test that QA datasets are built correctly."""
+    """Test that RC datasets are built correctly."""
     cfg = deepcopy(dataset_config)
-    cfg.task = QA
+    cfg.task = RC
     dataset = dataset_factory.build_dataset(dataset=cfg)
     assert isinstance(dataset, QuestionAnswering)
 
@@ -84,6 +84,14 @@ def test_build_common_sense_dataset(dataset_factory, dataset_config):
     cfg.task = COMMON_SENSE
     dataset = dataset_factory.build_dataset(dataset=cfg)
     assert isinstance(dataset, SequenceClassification)
+
+
+def test_build_mcrc_dataset(dataset_factory, dataset_config):
+    """Test that MCRC datasets are built correctly."""
+    cfg = deepcopy(dataset_config)
+    cfg.task = MCRC
+    dataset = dataset_factory.build_dataset(dataset=cfg)
+    assert isinstance(dataset, QuestionAnswering)
 
 
 @pytest.mark.skip(reason="Text modelling datasets are not yet implemented.")

--- a/tests/test_dataset_factory.py
+++ b/tests/test_dataset_factory.py
@@ -91,7 +91,7 @@ def test_build_mcrc_dataset(dataset_factory, dataset_config):
     cfg = deepcopy(dataset_config)
     cfg.task = MCRC
     dataset = dataset_factory.build_dataset(dataset=cfg)
-    assert isinstance(dataset, QuestionAnswering)
+    assert isinstance(dataset, SequenceClassification)
 
 
 @pytest.mark.skip(reason="Text modelling datasets are not yet implemented.")

--- a/tests/test_dataset_tasks.py
+++ b/tests/test_dataset_tasks.py
@@ -29,12 +29,13 @@ class TestGetAllTasks:
         [
             "linguistic-acceptability",
             "named-entity-recognition",
-            "question-answering",
+            "reading-comprehension",
             "sentiment-classification",
             "summarization",
             "knowledge",
             "common-sense-reasoning",
             "text-modelling",
+            "multiple-choice-reading-comprehension",
             "speed",
         ],
     )

--- a/tests/test_question_answering.py
+++ b/tests/test_question_answering.py
@@ -10,7 +10,7 @@ from scandeval.dataset_configs import get_all_dataset_configs
 from scandeval.exceptions import InvalidBenchmark
 from scandeval.languages import DA
 from scandeval.question_answering import QuestionAnswering, prepare_train_examples
-from scandeval.tasks import QA
+from scandeval.tasks import RC
 from scandeval.utils import GENERATIVE_DATASET_TASKS
 from transformers import AutoTokenizer
 
@@ -20,7 +20,7 @@ from transformers import AutoTokenizer
     params=[
         dataset_config
         for dataset_config in get_all_dataset_configs().values()
-        if dataset_config.task == QA
+        if dataset_config.task == RC
         and (
             os.getenv("TEST_ALL_DATASETS", "0") == "1"
             or (not dataset_config.unofficial and dataset_config.languages == [DA])


### PR DESCRIPTION
### Added
- Added the Belebele dataset, being a multilingual multiple-choice reading comprehension
  dataset. This has been added as a separate `multiple-choice-reading-comprehension`
  task, and is available in all supported languages except Faroese. The dataset has been
  marked as unofficial, meaning that it will not be automatically included when
  benchmarking models, but can be included by specifying the dataset explicitly using
  the `--dataset` argument (or `dataset` argument if using the `Benchmarker` API).

### Changed
- Changed the name of the `question-answering` task to the more descriptive name
  `reading-comprehension`.

This closes #501.