### PR TITLE
Feat/add dutch cola

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added the Dutch linguistic acceptability dataset `dutch-cola`. It has been set to
+  `unofficial` for now, but it might eventually replace ScaLA-nl as the official Dutch
+  linguistic acceptability dataset. For now, you can benchmark models on it by
+  explicitly setting the dataset using the `--dataset` argument (or `dataset` argument
+  if using the `Benchmarker` API).
+
 ### Fixed
 - Update `vllm` to `>=0.5.2` and `transformers` to `>=4.42.4`, which now allows
   evaluation of Gemma 2 models.

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -576,6 +576,37 @@ SCALA_EN_CONFIG = DatasetConfig(
     max_generated_tokens=1,
 )
 
+DUTCH_COLA_CONFIG = DatasetConfig(
+    name="dutch-cola",
+    pretty_name="the truncated version of the Dutch linguistic acceptability dataset "
+    "Dutch CoLA",
+    huggingface_id="ScandEval/dutch-cola",
+    task=LA,
+    languages=[NL],
+    prompt_prefix="Hieronder staan zinnen en of ze grammaticaal correct ('ja') of "
+    "incorrect ('nee') zijn.",
+    prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
+    prompt_label_mapping=dict(correct="ja", incorrect="nee"),
+    num_few_shot_examples=12,
+    max_generated_tokens=3,
+    unofficial=True,
+)
+
+DUTCH_COLA_FULL_CONFIG = DatasetConfig(
+    name="dutch-cola-full",
+    pretty_name="the Dutch linguistic acceptability dataset Dutch CoLA",
+    huggingface_id="ScandEval/dutch-cola-full",
+    task=LA,
+    languages=[NL],
+    prompt_prefix="Hieronder staan zinnen en of ze grammaticaal correct ('ja') of "
+    "incorrect ('nee') zijn.",
+    prompt_template="Zin: {text}\nGrammaticaal correct: {label}",
+    prompt_label_mapping=dict(correct="ja", incorrect="nee"),
+    num_few_shot_examples=12,
+    max_generated_tokens=3,
+    unofficial=True,
+)
+
 
 ### EXTRACTIVE QUESTION ANSWERING DATASETS ###
 

--- a/src/scripts/create_dutch_cola.py
+++ b/src/scripts/create_dutch_cola.py
@@ -40,7 +40,7 @@ def main() -> None:
 
     # Convert the dataset to a dataframe
     train_df = dataset["train"].to_pandas()
-    val_df = dataset["validation"].to_pandas()
+    val_df = dataset["val"].to_pandas()
     test_df = dataset["test"].to_pandas()
     assert isinstance(train_df, pd.DataFrame)
     assert isinstance(val_df, pd.DataFrame)
@@ -48,15 +48,45 @@ def main() -> None:
 
     # Create validation split
     val_size = 256
-    val_df = val_df.sample(n=val_size, random_state=4242)
+    incorrect_val_df = val_df.query("label == 'incorrect'").sample(
+        val_size // 2, random_state=4242
+    )
+    correct_val_df = val_df.query("label == 'correct'").sample(
+        val_size // 2, random_state=4242
+    )
+    val_df = (
+        pd.concat([incorrect_val_df, correct_val_df])
+        .sample(frac=1.0, random_state=4242)
+        .reset_index(drop=True)
+    )
 
     # Create test split
     test_size = 2048
-    test_df = test_df.sample(n=test_size, random_state=4242)
+    incorrect_test_df = test_df.query("label == 'incorrect'").sample(
+        test_size // 2, random_state=4242
+    )
+    correct_test_df = test_df.query("label == 'correct'").sample(
+        test_size // 2, random_state=4242
+    )
+    test_df = (
+        pd.concat([incorrect_test_df, correct_test_df])
+        .sample(frac=1.0, random_state=4242)
+        .reset_index(drop=True)
+    )
 
     # Create train split
     train_size = 1024
-    train_df = train_df.sample(n=train_size, random_state=4242)
+    incorrect_train_df = train_df.query("label == 'incorrect'").sample(
+        train_size // 2, random_state=4242
+    )
+    correct_train_df = train_df.query("label == 'correct'").sample(
+        train_size // 2, random_state=4242
+    )
+    train_df = (
+        pd.concat([incorrect_train_df, correct_train_df])
+        .sample(frac=1.0, random_state=4242)
+        .reset_index(drop=True)
+    )
 
     # Reset the index
     train_df = train_df.reset_index(drop=True)

--- a/src/scripts/create_dutch_cola.py
+++ b/src/scripts/create_dutch_cola.py
@@ -1,0 +1,77 @@
+"""Create the Dutch CoLA dataset and upload it to the HF Hub."""
+
+import pandas as pd
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main() -> None:
+    """Create the Dutch CoLA dataset and upload it to the HF Hub."""
+    # Define the base download URL
+    repo_id = "GroNLP/dutch-cola"
+
+    # Download the dataset
+    dataset = load_dataset(path=repo_id, token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    dataset = (
+        dataset.select_columns(["Sentence", "Acceptability"])
+        .rename_columns({"Sentence": "text", "Acceptability": "label"})
+        .shuffle(4242)
+    )
+
+    label_mapping = {0: "incorrect", 1: "correct"}
+    dataset = dataset.map(lambda sample: {"label": label_mapping[sample["label"]]})
+    dataset["val"] = dataset.pop("validation")
+
+    full_dataset_id = "ScandEval/dutch-cola-full"
+    dataset_id = "ScandEval/dutch-cola"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    for repo_id in [dataset_id, full_dataset_id]:
+        try:
+            api = HfApi()
+            api.delete_repo(repo_id, repo_type="dataset", missing_ok=True)
+        except HTTPError:
+            pass
+
+    dataset.push_to_hub(full_dataset_id, private=True)
+
+    # Convert the dataset to a dataframe
+    train_df = dataset["train"].to_pandas()
+    val_df = dataset["validation"].to_pandas()
+    test_df = dataset["test"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(val_df, pd.DataFrame)
+    assert isinstance(test_df, pd.DataFrame)
+
+    # Create validation split
+    val_size = 256
+    val_df = val_df.sample(n=val_size, random_state=4242)
+
+    # Create test split
+    test_size = 2048
+    test_df = test_df.sample(n=test_size, random_state=4242)
+
+    # Create train split
+    train_size = 1024
+    train_df = train_df.sample(n=train_size, random_state=4242)
+
+    # Reset the index
+    train_df = train_df.reset_index(drop=True)
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    dataset.push_to_hub(dataset_id, private=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Added
- Added the Dutch linguistic acceptability dataset `dutch-cola`. It has been set to
  `unofficial` for now, but it might eventually replace ScaLA-nl as the official Dutch
  linguistic acceptability dataset. For now, you can benchmark models on it by
  explicitly setting the dataset using the `--dataset` argument (or `dataset` argument
  if using the `Benchmarker` API).