### PR TITLE
fix: Set pad_token_id to the first eos_token_id if eos_token_id is a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This avoids OOM issues.
 - Adds GPT-4o and GPT-4o-mini to the list of cached OpenAI model IDs, to correctly
   determine if the model exists, without needing an OpenAI API key.
+- If a model has set its EOS token ID to multiple tokens and hasn't set the padding
+  token ID, we use the first EOS token ID as the padding token ID.
 
 
 ## [v13.0.0] - 2024-07-31

--- a/src/scandeval/model_setups/hf.py
+++ b/src/scandeval/model_setups/hf.py
@@ -545,7 +545,10 @@ class HFModelSetup:
                     cache_dir=model_cache_dir,
                 )
                 if config.eos_token_id is not None and config.pad_token_id is None:
-                    config.pad_token_id = config.eos_token_id
+                    if isinstance(config.eos_token_id, list):
+                        config.pad_token_id = config.eos_token_id[0]
+                    else:
+                        config.pad_token_id = config.eos_token_id
                 return config
             except KeyError as e:
                 key = e.args[0]


### PR DESCRIPTION
### Fixed
- If a model has set its EOS token ID to multiple tokens and hasn't set the padding
  token ID, we use the first EOS token ID as the padding token ID.