### PR TITLE
Add Schibsted dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Added
+- Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries),
+  which contains summaries of published articles from Schibsted Media's Norwegian and Swedish newsrooms.
+  The dataset has been split into two separate datasets, one for Swedish and one for Norwegian:
+  - `schibsted-sv` for Swedish
+  - `schibsted-no` for Norwegian
+  Both the dataset are currently listed as unofficial, meaning that they will not be automatically included when benchmarking models, but can be included by specifying the dataset explicitly using the `--dataset` argument (or `dataset` argument if using the `Benchmarker` API).
 
 ## [Unreleased]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries),
-  which contains summaries of published articles from Schibsted Media's Norwegian
-  and Swedish newsrooms. The dataset has been split into two separate datasets,
-  one for Swedish and one for Norwegian:
-  - `schibsted-sv` for Swedish
-  - `schibsted-no` for Norwegian
-  Both the dataset are currently listed as unofficial, meaning that they will not be
+- Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries), which contains summaries of published articles from Schibsted Media's Norwegian and Swedish newsrooms. The dataset has been split into two separate small datasets, one for Swedish and one for Norwegian:
+  - `schibsted-sv` for Swedish (train: 528 samples, val: 96 samples, test: 89 samples)
+  - `schibsted-no` for Norwegian (train: 528 samples, val: 96 samples, test: 89 samples)
+
+  Both the datasets are currently listed as unofficial, meaning that they will not be
   automatically included when benchmarking models, but can be included by specifying
   the dataset explicitly using the `--dataset` argument (or `dataset` argument if using
   the `Benchmarker` API).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries),
-  which contains summaries of published articles from Schibsted Media's Norwegian and Swedish newsrooms.
-  The dataset has been split into two separate datasets, one for Swedish and one for Norwegian:
+  which contains summaries of published articles from Schibsted Media's Norwegian
+  and Swedish newsrooms. The dataset has been split into two separate datasets,
+  one for Swedish and one for Norwegian:
   - `schibsted-sv` for Swedish
   - `schibsted-no` for Norwegian
-  Both the dataset are currently listed as unofficial, meaning that they will not be automatically included when benchmarking models, but can be included by specifying the dataset explicitly using the `--dataset` argument (or `dataset` argument if using the `Benchmarker` API).
-
-### Added
+  Both the dataset are currently listed as unofficial, meaning that they will not be
+  automatically included when benchmarking models, but can be included by specifying
+  the dataset explicitly using the `--dataset` argument (or `dataset` argument if using
+  the `Benchmarker` API).
 - Added the new Faroese reading comprehension dataset FoQA. This is now the default
   Faroese reading comprehension benchmark, as there was none previously.
 - Now supports evaluation of models with adapters. This requires that the model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries), which contains summaries of published articles from Schibsted Media's Norwegian and Swedish newsrooms. The dataset has been split into two separate small datasets, one for Swedish and one for Norwegian:
   - `schibsted-sv` for Swedish (train: 528 samples, val: 96 samples, test: 89 samples)
-  - `schibsted-no` for Norwegian (train: 528 samples, val: 96 samples, test: 89 samples)
+  - `schibsted-no` for Norwegian (train: 1240 samples, val: 347 samples, test: 374 samples)
 
   Both the datasets are currently listed as unofficial, meaning that they will not be
   automatically included when benchmarking models, but can be included by specifying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+
+## [Unreleased]
+
 ### Added
 - Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries),
   which contains summaries of published articles from Schibsted Media's Norwegian and Swedish newsrooms.
@@ -13,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `schibsted-no` for Norwegian
   Both the dataset are currently listed as unofficial, meaning that they will not be automatically included when benchmarking models, but can be included by specifying the dataset explicitly using the `--dataset` argument (or `dataset` argument if using the `Benchmarker` API).
 
-## [Unreleased]
 ### Added
 - Added the new Faroese reading comprehension dataset FoQA. This is now the default
   Faroese reading comprehension benchmark, as there was none previously.

--- a/poetry.lock
+++ b/poetry.lock
@@ -975,6 +975,22 @@ files = [
 devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
 
 [[package]]
+name = "fasttext"
+version = "0.9.3"
+description = "fasttext Python bindings"
+optional = false
+python-versions = "*"
+files = [
+    {file = "fasttext-0.9.3-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:8b39f3ac5df43873648ea400cb75d4f7f9455730ac5105490b23b70f14e03ea7"},
+    {file = "fasttext-0.9.3.tar.gz", hash = "sha256:eb03f2ef6340c6ac9e4398a30026f05471da99381b307aafe2f56e4cd26baaef"},
+]
+
+[package.dependencies]
+numpy = "*"
+pybind11 = ">=2.2"
+setuptools = ">=0.7.0"
+
+[[package]]
 name = "ffmpy"
 version = "0.4.0"
 description = "A simple Python wrapper for FFmpeg"
@@ -3048,7 +3064,6 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
 ]
@@ -3725,6 +3740,20 @@ files = [
 ]
 
 [[package]]
+name = "pybind11"
+version = "2.13.6"
+description = "Seamless operability between C++11 and Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pybind11-2.13.6-py3-none-any.whl", hash = "sha256:237c41e29157b962835d356b370ededd57594a26d5894a795960f0047cb5caf5"},
+    {file = "pybind11-2.13.6.tar.gz", hash = "sha256:ba6af10348c12b24e92fa086b39cfba0eff619b61ac77c406167d813b096d39a"},
+]
+
+[package.extras]
+global = ["pybind11-global (==2.13.6)"]
+
+[[package]]
 name = "pycountry"
 version = "24.6.1"
 description = "ISO country, subdivision, language, currency and script definitions and their translations"
@@ -4068,7 +4097,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4996,7 +5024,7 @@ scikit-learn = ">=0.21.3"
 name = "setuptools"
 version = "75.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
@@ -6218,4 +6246,4 @@ openai = ["bert-score", "levenshtein", "openai", "rouge-score", "tiktoken"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "2241668e6e5a863202c677fae7147d5a0bbe80950fd6766557c78a15cbf88a06"
+content-hash = "f7c454b68c25643a0c39083a927e52a61d2cbc772679825bf369b1c48e0cfb29"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6246,4 +6246,4 @@ openai = ["bert-score", "levenshtein", "openai", "rouge-score", "tiktoken"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "f7c454b68c25643a0c39083a927e52a61d2cbc772679825bf369b1c48e0cfb29"
+content-hash = "61ed9a2f8c36f375b87a5b89e2804a582dd1666f3124548533bc5ac59715aa9b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ levenshtein = { version = ">=0.24.0", optional = true }  # This is also used for
 
 # Needed for human evaluation
 gradio = { version = ">=4.26.0", optional = true }
+fasttext = "^0.9.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ levenshtein = { version = ">=0.24.0", optional = true }  # This is also used for
 
 # Needed for human evaluation
 gradio = { version = ">=4.26.0", optional = true }
-fasttext = "^0.9.3"
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.1.1"
@@ -68,6 +68,7 @@ ruff = ">=0.3.2"
 mypy = ">=1.9.0"
 nbstripout = ">=0.7.1"
 peft = ">=0.13.2"
+fasttext = "^0.9.3"
 
 [tool.poetry.extras]
 jax = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ levenshtein = { version = ">=0.24.0", optional = true }  # This is also used for
 # Needed for human evaluation
 gradio = { version = ">=4.26.0", optional = true }
 
-
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.1.1"
 pre-commit = ">=3.6.2"

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -923,6 +923,36 @@ CNN_DAILYMAIL_CONFIG = DatasetConfig(
     max_generated_tokens=256,
 )
 
+SCHIBSTED_SV = DatasetConfig(
+    name="schibsted-sv",
+    pretty_name="article summaries from Schibsted Media Swedish newsrooms.",
+    huggingface_id="ScandEval/schibsted-article-summaries-sv",
+    task=SUMM,
+    languages=[SV],
+    prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
+    prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
+    instruction_prompt="Nyhedsartikel: {text}\n\nSkriv et resumé af ovenstående "
+    "artikel.",
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
+    unofficial=True,
+)
+
+SCHIBSTED_NO = DatasetConfig(
+    name="schibsted-no",
+    pretty_name="article summaries from Schibsted Medias Norwegian newsrooms.",
+    huggingface_id="ScandEval/schibsted-article-summaries-no",
+    task=SUMM,
+    languages=[NB, NN, NO],
+    prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
+    prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
+    instruction_prompt="Nyhedsartikel: {text}\n\nSkriv et resumé af ovenstående "
+    "artikel.",
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
+    unofficial=True,
+)
+
 # TODO: Faroese summarization
 
 

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -929,10 +929,9 @@ SCHIBSTED_SV = DatasetConfig(
     huggingface_id="ScandEval/schibsted-article-summaries-sv",
     task=SUMM,
     languages=[SV],
-    prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
-    prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
-    instruction_prompt="Nyhedsartikel: {text}\n\nSkriv et resumé af ovenstående "
-    "artikel.",
+    prompt_prefix="Nedan följer artiklar med tillhörande sammanfattningar.",
+    prompt_template="Artikel: {text}\nSammanfattning: {target_text}",
+    instruction_prompt="Artikel: {text}\n\nSkriv en sammanfattning av artikeln ovan.",
     num_few_shot_examples=1,
     max_generated_tokens=256,
     unofficial=True,
@@ -944,10 +943,10 @@ SCHIBSTED_NO = DatasetConfig(
     huggingface_id="ScandEval/schibsted-article-summaries-no",
     task=SUMM,
     languages=[NB, NN, NO],
-    prompt_prefix="Følgende er nyhedsartikler med tilhørende resuméer.",
-    prompt_template="Nyhedsartikel: {text}\nResumé: {target_text}",
-    instruction_prompt="Nyhedsartikel: {text}\n\nSkriv et resumé af ovenstående "
-    "artikel.",
+    prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
+    prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
+    instruction_prompt="Nyhetsartikkel: {text}\n\nSkriv et sammendrag av den "
+    "ovennevnte artikkelen.",
     num_few_shot_examples=1,
     max_generated_tokens=256,
     unofficial=True,

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -64,12 +64,11 @@ def main():
         """Detect if the text is in Swedish or Norwegian.
 
         Args:
-            text (str):
+            text:
                 The text to detect the language of.
 
         Returns:
-            str:
-                The language of the text ("sv" or "no").
+            The language of the text ("sv" or "no").
         """
         label, _ = model.predict(text=text)
         label = label[0]

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -1,0 +1,108 @@
+"""Create the Schibsted summarisation dataset."""
+
+import fasttext
+import pandas as pd
+from constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi, hf_hub_download
+from requests import HTTPError
+
+
+def main():
+    """Create the Schibsted summarisation dataset and upload to HF Hub."""
+    dataset_id = "Schibsted/schibsted-article-summaries"
+
+    dataset = load_dataset(dataset_id, token=True)
+    assert isinstance(dataset, DatasetDict)
+
+    # Rename validation split to val
+    dataset["val"] = dataset.pop("validation")
+
+    # Rename article_text_all to text
+    dataset = dataset.rename_columns(column_mapping=dict(article_text_all="text", summary="target_text"))
+
+    # Add article title to text, separated by a colon
+    dataset = dataset.map(lambda x: {"text": f"{x['article_title']}: {x['text']}"})
+
+    # Summary is a list of strings, but should be a single string
+    dataset = dataset.map(lambda x: {"target_text": " ".join(x["target_text"])})
+
+    # Ignore samples outside the bounds
+    train_df = dataset["train"].to_pandas()
+    val_df = dataset["val"].to_pandas()
+    test_df = dataset["test"].to_pandas()
+    assert isinstance(train_df, pd.DataFrame)
+    assert isinstance(val_df, pd.DataFrame)
+    assert isinstance(test_df, pd.DataFrame)
+
+    # Only work with samples where the text is not very large or small
+    train_lengths = train_df.text.str.len()
+    val_lengths = val_df.text.str.len()
+    test_lengths = test_df.text.str.len()
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
+    train_df = train_df[train_lengths.between(lower_bound, upper_bound)]
+    val_df = val_df[val_lengths.between(lower_bound, upper_bound)]
+    test_df = test_df[test_lengths.between(lower_bound, upper_bound)]
+
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Dataset is a mix of Swedish and Norwegian articles.
+    # Make two separate datasets, one for each language.
+    model_path = hf_hub_download(
+        repo_id="facebook/fasttext-language-identification", filename="model.bin"
+    )
+    model = fasttext.load_model(model_path)
+
+    def detect_language(text: str) -> str:
+        """Detect if the text is in Swedish or Norwegian.
+
+        Args:
+            text (str):
+                The text to detect the language of.
+
+        Returns:
+            str:
+                The language of the text ("sv" or "no").
+        """
+        label, _ = model.predict(text=text)
+        label = label[0]
+        if label == "__label__swe_Latn":
+            return "sv"
+        elif label == "__label__nob_Latn" or label == "__label__nno_Latn":
+            return "no"
+        return "other"
+        # print(f"Not Swedish or Norwegian ({label}): {text}")
+
+    dataset_sv = dataset.filter(
+        lambda x: detect_language(text=x["article_title"]) == "sv"
+    )
+    dataset_no = dataset.filter(
+        lambda x: detect_language(text=x["article_title"]) == "no"
+    )
+
+    # Dataset IDs.
+    dataset_id_sv = "ScandEval/schibsted-article-summaries-sv"
+    dataset_id_no = "ScandEval/schibsted-article-summaries-no"
+
+    for dataset, dataset_id in [
+        (dataset_sv, dataset_id_sv),
+        (dataset_no, dataset_id_no),
+    ]:
+        # Remove the dataset from Hugging Face Hub if it already exists
+        try:
+            api: HfApi = HfApi()
+            api.delete_repo(dataset_id, repo_type="dataset")
+        except HTTPError:
+            pass
+
+        # Push the dataset to the Hugging Face Hub
+        dataset.push_to_hub(dataset_id, private=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -77,7 +77,6 @@ def main():
         elif label == "__label__nob_Latn" or label == "__label__nno_Latn":
             return "no"
         return "other"
-        # print(f"Not Swedish or Norwegian ({label}): {text}")
 
     dataset_sv = dataset.filter(
         lambda x: detect_language(text=x["article_title"]) == "sv"

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -19,7 +19,9 @@ def main():
     dataset["val"] = dataset.pop("validation")
 
     # Rename article_text_all to text
-    dataset = dataset.rename_columns(column_mapping=dict(article_text_all="text", summary="target_text"))
+    dataset = dataset.rename_columns(
+        column_mapping=dict(article_text_all="text", summary="target_text")
+    )
 
     # Add article title to text, separated by a colon
     dataset = dataset.map(lambda x: {"text": f"{x['article_title']}: {x['text']}"})


### PR DESCRIPTION
Added the [Schibsted dataset](https://huggingface.co/datasets/Schibsted/schibsted-article-summaries).

  The dataset has been split into two separate datasets, one for Swedish and one for Norwegian:
  - `schibsted-sv` for Swedish
  - `schibsted-no` for Norwegian

Fasttext is used to detect the language of a sample.

I have tried running `scandeval --model AI-Sweden-Models/gpt-sw3-126m-instruct --dataset schibsted-sv`. I get no errors, but my M1 gets multiple CPU spikes, so I have not tried to complete a run.

Fix https://github.com/ScandEval/ScandEval/issues/526