### PR TITLE
fix: Disallow empty stop tokens for vLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   token ID, we use the first EOS token ID as the padding token ID.
 - Fixed a bug related to the loading of some encoder models by updating `accelerate` to
   `>=0.34.2` and `transformers` to `>=4.45.0`.
+- We now ensure that stop tokens in vLLM can't be empty, as this caused errors when
+  evaluating some models.
 
 
 ## [v13.0.0] - 2024-07-31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ filterwarnings = [
     "ignore::PendingDeprecationWarning",
     "ignore::ImportWarning",
     "ignore::FutureWarning",
+    "ignore::ResourceWarning",
 ]
 log_cli_level = "info"
 testpaths = ["tests", "src/scandeval"]

--- a/src/scandeval/vllm_models.py
+++ b/src/scandeval/vllm_models.py
@@ -247,7 +247,7 @@ class VLLMModel:
             temperature=temperature,
             top_p=generation_config.top_p,
             top_k=generation_config.top_k,
-            stop=stop_tokens,
+            stop=[stop_token for stop_token in stop_tokens if stop_token],
             repetition_penalty=generation_config.repetition_penalty,
             frequency_penalty=generation_config.repetition_penalty - 1.0,
             logits_processors=generation_kwargs.get("logits_processors"),


### PR DESCRIPTION
### Fixed
- We now ensure that stop tokens in vLLM can't be empty, as this caused errors when
  evaluating some models.