### PR TITLE
fix: Deal with empty end-of-chat token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `>=0.34.2` and `transformers` to `>=4.45.0`.
 - We now ensure that stop tokens in vLLM can't be empty, as this caused errors when
   evaluating some models.
+- If the end-of-chat-token for a model only consists of whitespace and/or newlines then
+  we ignore it, as this caused errors when evaluating some models and makes no
+  difference to the evaluation of the model, since we are stripping the output anyway.
 
 
 ## [v13.0.0] - 2024-07-31

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -556,10 +556,11 @@ def extract_raw_predictions(
     end_of_chat_token_ids = get_end_of_chat_token_ids(tokenizer=tokenizer)
     if end_of_chat_token_ids is not None:
         end_of_chat_token = tokenizer.decode(end_of_chat_token_ids).strip()
-        raw_predictions = [
-            raw_prediction.split(end_of_chat_token)[0]
-            for raw_prediction in raw_predictions
-        ]
+        if end_of_chat_token:
+            raw_predictions = [
+                raw_prediction.split(end_of_chat_token)[0]
+                for raw_prediction in raw_predictions
+            ]
 
     raw_predictions = [raw_prediction.strip() for raw_prediction in raw_predictions]
 

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -727,9 +727,10 @@ def get_end_of_chat_token_ids(tokenizer: "Tokenizer") -> list[int] | None:
     if tokenizer.chat_template is None:
         return None
 
-    token_ids = tokenizer.apply_chat_template(
-        conversation=[dict(role="user", content="X")]
-    )
+    user_message: dict[Literal["role", "content"], str] = dict()
+    user_message["role"] = "user"
+    user_message["content"] = "X"
+    token_ids = tokenizer.apply_chat_template(conversation=[user_message])
     assert isinstance(token_ids, list)
 
     for idx, token in enumerate(tokenizer.convert_ids_to_tokens(token_ids)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,6 +126,7 @@ def test_should_prefix_space_be_added_to_labels(model_id, expected, auth):
         ("Qwen/Qwen1.5-0.5B-Chat", [151645, 198], "<|im_end|>"),
         ("norallm/normistral-7b-warm", None, None),
         ("norallm/normistral-7b-warm-instruct", [4, 217], "<|im_end|>"),
+        ("ibm-granite/granite-3b-code-instruct-2k", [478], ""),
     ],
 )
 def test_get_end_of_chat_token_ids(model_id, expected_token_ids, expected_string, auth):


### PR DESCRIPTION
### Fixed
- If the end-of-chat-token for a model only consists of whitespace and/or newlines then
  we ignore it, as this caused errors when evaluating some models and makes no
  difference to the evaluation of the model, since we are stripping the output anyway.

Fixes #563 