### PR TITLE
Add summarisation part of the NorGLM NO-Multi-QA-Sum dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-## [v13.1.0] - 2024-10-31
+## [Unreleased]
 ### Added
 - Added the summarisation part of the Norwegian NorGLM multi-task human annotated
   dataset NO-Multi-QA-Sum. This dataset is part of the It is a part of NLEBench
   Norwegian benchmarks. It has been marked as `unofficial` for now.
+
+## [v13.1.0] - 2024-10-31
+### Added
 - Added `ice-ec` (a subset of the dataset) and `ice-ec-full` (the full dataset), an
   Icelandic linguistic acceptability dataset. It has been set to `unofficial` for now.
 - Added the Schibsted summarisation dataset, which contains summaries of published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v13.1.0] - 2024-10-31
 ### Added
+- Added the summarisation part of the Norwegian NorGLM multi-task human annotated
+  dataset NO-Multi-QA-Sum. This dataset is part of the It is a part of NLEBench
+  Norwegian benchmarks. It has been marked as `unofficial` for now.
 - Added `ice-ec` (a subset of the dataset) and `ice-ec-full` (the full dataset), an
   Icelandic linguistic acceptability dataset. It has been set to `unofficial` for now.
 - Added the Schibsted summarisation dataset, which contains summaries of published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added the summarisation part of the Norwegian NorGLM multi-task human annotated
-  dataset NO-Multi-QA-Sum. This dataset is part of the It is a part of NLEBench
+  dataset NO-Multi-QA-Sum (`norglm-multi-sum`). This dataset is part of the NLEBench
   Norwegian benchmarks. It has been marked as `unofficial` for now.
 
 ## [v13.1.0] - 2024-10-31

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -926,6 +926,22 @@ NO_SAMMENDRAG_CONFIG = DatasetConfig(
     max_generated_tokens=256,
 )
 
+NORGLM_MULTI_SUM = DatasetConfig(
+    name="norglm-multi-sum",
+    pretty_name="the summarisation part of the Norwegian NorGLM multi-task human annotated dataset "
+    "NO-Multi-QA-Sum",
+    huggingface_id="ScandEval/norglm-multi-sum",
+    task=SUMM,
+    languages=[NB, NN, NO],
+    prompt_prefix="Her følger nyhetsartikler med tilhørende sammendrag.",
+    prompt_template="Nyhetsartikkel: {text}\nSammendrag: {target_text}",
+    instruction_prompt="Nyhetsartikkel: {text}\n\nSkriv et sammendrag av den "
+    "ovennevnte artikkelen.",
+    num_few_shot_examples=1,
+    max_generated_tokens=256,
+    unofficial=True,
+)
+
 WIKI_LINGUA_NL_CONFIG = DatasetConfig(
     name="wiki-lingua-nl",
     pretty_name="the Dutch part of the truncated version of the summarisation dataset "

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -21,8 +21,19 @@ def main():
     df = dataset.to_pandas()
     assert isinstance(df, pd.DataFrame)
 
-    # Only work with samples where the text is not very large or small
+    # Drop unneeded index column
+    df.drop("Unnamed: 0", inplace=True, axis=1)
 
+    # Drop non-article by index
+    df.drop(index=359, inplace=True)
+
+    # Shuffle and drop first duplicate
+    df = df.sample(frac=1).drop_duplicates(subset="article")
+
+    # Reset the index
+    df = df.reset_index(drop=True)
+
+    # Only work with samples where the text is not very large or small
     lengths = df.text.str.len()
     lower_bound = MIN_NUM_CHARS_IN_ARTICLE
     upper_bound = MAX_NUM_CHARS_IN_ARTICLE
@@ -38,9 +49,7 @@ def main():
     test_df = filtered_df.sample(n=test_size, random_state=4242)
 
     # Create train split
-    train_size = 147
-    filtered_df = filtered_df[~filtered_df.index.isin(test_df.index)]
-    train_df = filtered_df.sample(n=train_size, random_state=4242)
+    train_df = filtered_df[~filtered_df.index.isin(test_df.index)]
 
     val_df = val_df.reset_index(drop=True)
     test_df = test_df.reset_index(drop=True)

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -28,7 +28,7 @@ def main():
     df.drop(index=359, inplace=True)
 
     # Shuffle and drop first duplicate
-    df = df.sample(frac=1).drop_duplicates(subset="text")
+    df = df.sample(frac=1, random_state=4242).drop_duplicates(subset="text")
 
     # Reset the index
     df = df.reset_index(drop=True)

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -1,0 +1,71 @@
+"""Create the NorGLM NO-multi summarisation dataset."""
+
+import pandas as pd
+from constants import MAX_NUM_CHARS_IN_ARTICLE, MIN_NUM_CHARS_IN_ARTICLE
+from datasets import Dataset, DatasetDict, Split, load_dataset
+from huggingface_hub import HfApi
+from requests import HTTPError
+
+
+def main():
+    """Create the NorGLM NO-multi summarisation dataset and upload to HF Hub."""
+    dataset_id = "NorGLM/NO-Multi-QA-Sum"
+
+    dataset = load_dataset(dataset_id, split="train", token=True)
+    assert isinstance(dataset, Dataset)
+
+    dataset = dataset.rename_columns(
+        column_mapping=dict(article="text", summary="target_text")
+    )
+
+    df = dataset.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+
+    # Only work with samples where the text is not very large or small
+
+    lengths = df.text.str.len()
+    lower_bound = MIN_NUM_CHARS_IN_ARTICLE
+    upper_bound = MAX_NUM_CHARS_IN_ARTICLE
+    df = df[lengths.between(lower_bound, upper_bound)]
+
+    # Create validation split
+    val_size = 64
+    val_df = df.sample(n=val_size, random_state=4242)
+
+    # Create test split
+    test_size = 256
+    filtered_df = df[~df.index.isin(val_df.index)]
+    test_df = filtered_df.sample(n=test_size, random_state=4242)
+
+    # Create train split
+    train_size = 147
+    filtered_df = filtered_df[~filtered_df.index.isin(test_df.index)]
+    train_df = filtered_df.sample(n=train_size, random_state=4242)
+
+    val_df = val_df.reset_index(drop=True)
+    test_df = test_df.reset_index(drop=True)
+    train_df = train_df.reset_index(drop=True)
+
+    # Collect datasets in a dataset dictionary
+    dataset = DatasetDict(
+        train=Dataset.from_pandas(train_df, split=Split.TRAIN),
+        val=Dataset.from_pandas(val_df, split=Split.VALIDATION),
+        test=Dataset.from_pandas(test_df, split=Split.TEST),
+    )
+
+    # Create dataset ID
+    dataset_id = "ScandEval/norglm-multi-sum"
+
+    # Remove the dataset from Hugging Face Hub if it already exists
+    try:
+        api: HfApi = HfApi()
+        api.delete_repo(dataset_id, repo_type="dataset")
+    except HTTPError:
+        pass
+
+    # Push the dataset to the Hugging Face Hub
+    dataset.push_to_hub(dataset_id, private=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/create_norglm_multisum.py
+++ b/src/scripts/create_norglm_multisum.py
@@ -28,7 +28,7 @@ def main():
     df.drop(index=359, inplace=True)
 
     # Shuffle and drop first duplicate
-    df = df.sample(frac=1).drop_duplicates(subset="article")
+    df = df.sample(frac=1).drop_duplicates(subset="text")
 
     # Reset the index
     df = df.reset_index(drop=True)


### PR DESCRIPTION
Added the [NorGLM NO-Multi-QA-Sum dataset](https://huggingface.co/datasets/NorGLM/NO-Multi-QA-Sum)

I have tried to use the dataset by running
scandeval --model mhenrichsen/danskgpt-tiny --dataset norglm-multi-sum. I do not seem to get any errors, although it is running rather slow (I think this is a standing issue with my machine - have not tried to debug further yet).

Fixes part of #536

The dataset is somewhat small and consists of 467 samples with the following splits:

- 147 training samples
- 64 validation samples
- 256 test samples

Working on adding the question and answer part of the same dataset as well.