### PR TITLE
Remove automatic language identification

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -975,22 +975,6 @@ files = [
 devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
 
 [[package]]
-name = "fasttext"
-version = "0.9.3"
-description = "fasttext Python bindings"
-optional = false
-python-versions = "*"
-files = [
-    {file = "fasttext-0.9.3-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:8b39f3ac5df43873648ea400cb75d4f7f9455730ac5105490b23b70f14e03ea7"},
-    {file = "fasttext-0.9.3.tar.gz", hash = "sha256:eb03f2ef6340c6ac9e4398a30026f05471da99381b307aafe2f56e4cd26baaef"},
-]
-
-[package.dependencies]
-numpy = "*"
-pybind11 = ">=2.2"
-setuptools = ">=0.7.0"
-
-[[package]]
 name = "ffmpy"
 version = "0.4.0"
 description = "A simple Python wrapper for FFmpeg"
@@ -3740,20 +3724,6 @@ files = [
 ]
 
 [[package]]
-name = "pybind11"
-version = "2.13.6"
-description = "Seamless operability between C++11 and Python"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pybind11-2.13.6-py3-none-any.whl", hash = "sha256:237c41e29157b962835d356b370ededd57594a26d5894a795960f0047cb5caf5"},
-    {file = "pybind11-2.13.6.tar.gz", hash = "sha256:ba6af10348c12b24e92fa086b39cfba0eff619b61ac77c406167d813b096d39a"},
-]
-
-[package.extras]
-global = ["pybind11-global (==2.13.6)"]
-
-[[package]]
 name = "pycountry"
 version = "24.6.1"
 description = "ISO country, subdivision, language, currency and script definitions and their translations"
@@ -5024,7 +4994,7 @@ scikit-learn = ">=0.21.3"
 name = "setuptools"
 version = "75.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "setuptools-75.2.0-py3-none-any.whl", hash = "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"},
@@ -6246,4 +6216,4 @@ openai = ["bert-score", "levenshtein", "openai", "rouge-score", "tiktoken"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "61ed9a2f8c36f375b87a5b89e2804a582dd1666f3124548533bc5ac59715aa9b"
+content-hash = "2241668e6e5a863202c677fae7147d5a0bbe80950fd6766557c78a15cbf88a06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ ruff = ">=0.3.2"
 mypy = ">=1.9.0"
 nbstripout = ">=0.7.1"
 peft = ">=0.13.2"
-fasttext = "^0.9.3"
 
 [tool.poetry.extras]
 jax = [

--- a/src/scripts/create_schibsted.py
+++ b/src/scripts/create_schibsted.py
@@ -18,7 +18,7 @@ NEWSROOM_TO_LANGUAGE = {
     "vg": "no",
     "ap": "no",
     "randaberg24": "no",
-    "ab": "se",
+    "ab": "sv",
     "sa": "no",
 }
 
@@ -74,7 +74,7 @@ def main():
 
     # Dataset is a mix of Swedish and Norwegian articles.
     # Make two separate datasets, one for each language.
-    dataset_sv = dataset.filter(lambda x: x["language"] == "se")
+    dataset_sv = dataset.filter(lambda x: x["language"] == "sv")
 
     dataset_no = dataset.filter(lambda x: x["language"] == "no")
 


### PR DESCRIPTION
Use hardcoded mapping from newsroom to language instead of doing language identification, as suggested in https://github.com/ScandEval/ScandEval/issues/526#issuecomment-2451747472.

Fix https://github.com/ScandEval/ScandEval/issues/526