### PR TITLE
Feat/use language tokeniser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - No more tokenisation for generation tasks, resulting in faster preprocessing times.
 - Now evaluates models on the validation split by default, to avoid overfitting to the
   test set. The test set can be evaluated on using the `--evaluate-test-split` flag.
+- Now evaluates instruction tuned models with their chat template. This _does_ often
+  result in worse scores, but it is more representative of how the model is used in
+  practice. Further, if a tokeniser has multiple chat templates, then we use the one
+  corresponding to the ISO 639-1 language code of the dataset, if available -
+  otherwise we will just use the default chat template of the tokeniser.
 
 ### Removed
 - Removed the option to evaluate on the training split, as this is not a common use

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -45,7 +45,12 @@ from ..task_utils import (
     token_classification,
 )
 from ..types import ExtractLabelsFunction
-from ..utils import clear_memory, create_model_cache_dir, get_end_of_chat_token_ids
+from ..utils import (
+    clear_memory,
+    create_model_cache_dir,
+    get_end_of_chat_token_ids,
+    log_once,
+)
 from .hf import HuggingFaceEncoderModel, get_model_repo_info
 
 if t.TYPE_CHECKING or importlib.util.find_spec("vllm") is not None:
@@ -769,8 +774,9 @@ class VLLMModel(HuggingFaceEncoderModel):
                 for name, candidate_template in self._tokenizer.chat_template.items():
                     if name.lower() in language_codes:
                         chat_template = candidate_template
-                        logger.debug(
-                            f"Using the {name!r} chat template for the tokenizer."
+                        log_once(
+                            f"Using the {name!r} chat template for the tokenizer.",
+                            level=logging.DEBUG,
                         )
                         break
 

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -10,6 +10,7 @@ import re
 import sys
 import typing as t
 import warnings
+from functools import cache
 from pathlib import Path
 
 import litellm
@@ -494,3 +495,31 @@ def unscramble(scrambled_text: str) -> str:
     inverse_permutation = np.argsort(permutation)
     unscrambled = "".join(scrambled_text[i] for i in inverse_permutation)
     return unscrambled
+
+
+@cache
+def log_once(message: str, level: int = logging.INFO) -> None:
+    """Log a message once.
+
+    This is ensured by caching the input/output pairs of this function, using the
+    `functools.cache` decorator.
+
+    Args:
+        message:
+            The message to log.
+        level:
+            The logging level. Defaults to logging.INFO.
+    """
+    match level:
+        case logging.DEBUG:
+            logger.debug(message)
+        case logging.INFO:
+            logger.info(message)
+        case logging.WARNING:
+            logger.warning(message)
+        case logging.ERROR:
+            logger.error(message)
+        case logging.CRITICAL:
+            logger.critical(message)
+        case _:
+            raise ValueError(f"Invalid logging level: {level}")


### PR DESCRIPTION
### Changed
- Now evaluates instruction tuned models with their chat template. This _does_ often
  result in worse scores, but it is more representative of how the model is used in
  practice. Further, if a tokeniser has multiple chat templates, then we use the one
  corresponding to the ISO 639-1 language code of the dataset, if available -
  otherwise we will just use the default chat template of the tokeniser.