### PR TITLE
feat: Add base_url argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   APIs can now be benchmarked! This includes OpenAI, Anthropic, Google, Mistral AI,
   Cohere, Ollama, LM Studio, vLLM servers, and Hugging Face inference endpoints. Check
   out the full list of LiteLLM providers [here](https://docs.litellm.ai/docs/providers).
+- Added new `--base-url` argument, which allows you to specify the base URL of your
+  model, if you are using an OpenAI-compatible inference API.
 
 ### Changed
 - No more tokenisation for generation tasks, resulting in faster preprocessing times.
 - Now evaluates models on the validation split by default, to avoid overfitting to the
-  test set. The test set can be evaluated on using the `--evaluate-test-split` flag.
+  test set. The test set can be evaluated on using the new `--evaluate-test-split` flag.
 
 ### Removed
 - Removed the option to evaluate on the training split, as this is not a common use

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -44,6 +44,7 @@ def build_benchmark_config(
     evaluate_test_split: bool,
     few_shot: bool,
     num_iterations: int,
+    base_url: str | None,
     debug: bool,
     run_with_cli: bool,
     first_time: bool = False,
@@ -106,6 +107,9 @@ def build_benchmark_config(
             Whether to use few-shot learning for the models.
         num_iterations:
             The number of iterations each model should be evaluated for.
+        base_url:
+            The base URL for a given inference API. Only relevant if `model` refers to a
+            model on an inference API.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -183,6 +187,7 @@ def build_benchmark_config(
         evaluate_test_split=evaluate_test_split,
         few_shot=few_shot,
         num_iterations=num_iterations,
+        base_url=base_url,
         debug=debug,
         run_with_cli=run_with_cli,
     )

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -31,7 +31,7 @@ from transformers import (
 )
 from urllib3.exceptions import RequestError
 
-from ..constants import DUMMY_FILL_VALUE, GENERATIVE_TAGS
+from ..constants import DUMMY_FILL_VALUE, GENERATIVE_MODEL_TASKS, GENERATIVE_TAGS
 from ..data_models import BenchmarkConfig, DatasetConfig, HFModelInfo, ModelConfig, Task
 from ..enums import BatchingPreference, Framework, ModelType
 from ..exceptions import (
@@ -389,7 +389,10 @@ class HuggingFaceEncoderModel(BenchmarkModule):
         model_info = get_model_repo_info(
             model_id=model_id, revision=revision, benchmark_config=benchmark_config
         )
-        return model_info is not None and model_info.pipeline_tag != "text-generation"
+        return (
+            model_info is not None
+            and model_info.pipeline_tag not in GENERATIVE_MODEL_TASKS
+        )
 
     @classmethod
     def get_model_config(

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -21,7 +21,12 @@ from tqdm.auto import tqdm
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer, Trainer
 from urllib3.exceptions import RequestError
 
-from ..constants import MAX_LOGPROBS, SUPERTASKS_USING_LOGPROBS, TASKS_USING_JSON
+from ..constants import (
+    GENERATIVE_MODEL_TASKS,
+    MAX_LOGPROBS,
+    SUPERTASKS_USING_LOGPROBS,
+    TASKS_USING_JSON,
+)
 from ..data_models import (
     BenchmarkConfig,
     DatasetConfig,
@@ -326,7 +331,9 @@ class VLLMModel(HuggingFaceEncoderModel):
         model_info = get_model_repo_info(
             model_id=model_id, revision=revision, benchmark_config=benchmark_config
         )
-        return model_info is not None and model_info.pipeline_tag == "text-generation"
+        return (
+            model_info is not None and model_info.pipeline_tag in GENERATIVE_MODEL_TASKS
+        )
 
     @classmethod
     def get_model_config(

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -75,6 +75,7 @@ class Benchmarker:
         evaluate_test_split: bool = False,
         few_shot: bool = True,
         num_iterations: int = 10,
+        base_url: str | None = None,
         debug: bool = False,
         run_with_cli: bool = False,
     ) -> None:
@@ -147,6 +148,9 @@ class Benchmarker:
                 The number of times each model should be evaluated. This is only meant
                 to be used for power users, and scores will not be allowed on the
                 leaderboards if this is changed. Defaults to 10.
+            base_url:
+                The base URL for a given inference API. Only relevant if `model` refers
+                to a model on an inference API. Defaults to None.
             debug:
                 Whether to output debug information. Defaults to False.
             run_with_cli:
@@ -183,6 +187,7 @@ class Benchmarker:
             evaluate_test_split=evaluate_test_split,
             few_shot=few_shot,
             num_iterations=num_iterations,
+            base_url=base_url,
             debug=debug,
             run_with_cli=run_with_cli,
         )

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -196,6 +196,13 @@ from .tasks import get_all_tasks
     is changed.""",
 )
 @click.option(
+    "--base-url",
+    default=None,
+    show_default=True,
+    help="The base URL for a given inference API. Only relevant if `model` refers to a "
+    "model on an inference API.",
+)
+@click.option(
     "--debug/--no-debug",
     default=False,
     show_default=True,
@@ -227,6 +234,7 @@ def benchmark(
     evaluate_test_split: bool,
     few_shot: bool,
     num_iterations: int,
+    base_url: str | None,
     debug: bool,
 ) -> None:
     """Benchmark pretrained language models on language tasks."""
@@ -262,6 +270,7 @@ def benchmark(
         evaluate_test_split=evaluate_test_split,
         few_shot=few_shot,
         num_iterations=num_iterations,
+        base_url=base_url,
         debug=debug,
         run_with_cli=True,
     )

--- a/src/scandeval/constants.py
+++ b/src/scandeval/constants.py
@@ -4,11 +4,7 @@
 DUMMY_FILL_VALUE = 100
 
 
-GENERATIVE_MODEL_TASKS = [
-    "text-generation",
-    "conversational",
-    # "text2text-generation",  # TODO: Add this when we support it
-]
+GENERATIVE_MODEL_TASKS = ["text-generation", "conversational", "text2text-generation"]
 
 
 GENERATIVE_DATASET_TASKS = [

--- a/src/scandeval/data_models.py
+++ b/src/scandeval/data_models.py
@@ -149,6 +149,9 @@ class BenchmarkConfig:
             if the model is generative.
         num_iterations:
             The number of iterations each model should be evaluated for.
+        base_url:
+            The base URL for a given inference API. Only relevant if `model` refers to a
+            model on an inference API.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -176,6 +179,7 @@ class BenchmarkConfig:
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
+    base_url: str | None
     debug: bool
     run_with_cli: bool
 
@@ -207,6 +211,7 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
+    base_url: str | None
     debug: bool
     run_with_cli: bool
 

--- a/src/scandeval/enums.py
+++ b/src/scandeval/enums.py
@@ -60,8 +60,6 @@ class ModelType(AutoStrEnum):
             Hugging Face encoder model from the Hub.
         HF_HUB_GENERATIVE:
             Hugging Face generative model from the Hub.
-        LOCAL:
-            Locally stored model.
         API:
             Model accessed through an API.
         HUMAN:
@@ -71,7 +69,6 @@ class ModelType(AutoStrEnum):
     FRESH = auto()
     HF_HUB_ENCODER = auto()
     HF_HUB_GENERATIVE = auto()
-    LOCAL = auto()
     API = auto()
     HUMAN = auto()
 

--- a/src/scandeval/human_evaluation.py
+++ b/src/scandeval/human_evaluation.py
@@ -272,6 +272,7 @@ class HumanEvaluator:
             evaluate_test_split=False,
             few_shot=True,
             num_iterations=iteration + 1,
+            base_url=None,
             debug=False,
             run_with_cli=True,
         )

--- a/src/scandeval/model_loading.py
+++ b/src/scandeval/model_loading.py
@@ -41,7 +41,6 @@ def load_model(
         ModelType.HF_HUB_GENERATIVE: VLLMModel,
         ModelType.HF_HUB_ENCODER: HuggingFaceEncoderModel,
         ModelType.API: LiteLLMModel,
-        ModelType.LOCAL: VLLMModel,  # TODO: Add LocalModel
         ModelType.FRESH: FreshEncoderModel,
     }
     model_class = model_type_to_module_mapping[model_config.model_type]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ def benchmark_config(auth, device) -> Generator[BenchmarkConfig, None, None]:
         evaluate_test_split=False,
         few_shot=True,
         num_iterations=1,
+        base_url=None,
         debug=False,
         run_with_cli=True,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ def test_cli_param_names(params):
         "evaluate_test_split",
         "few_shot",
         "num_iterations",
+        "base_url",
         "debug",
         "help",
     }
@@ -72,5 +73,6 @@ def test_cli_param_types(params):
     assert params["evaluate_test_split"] == BOOL
     assert params["few_shot"] == BOOL
     assert params["num_iterations"] == INT
+    assert params["base_url"] == STRING
     assert params["debug"] == BOOL
     assert params["help"] == BOOL


### PR DESCRIPTION
### Added
- Added new `--base-url` argument, which allows you to specify the base URL of your
  model, if you are using an OpenAI-compatible inference API.