### PR TITLE
Fix/instruction prompt tuning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - No more tokenisation for generation tasks, resulting in faster preprocessing times.
 - Now evaluates models on the validation split by default, to avoid overfitting to the
   test set. The test set can be evaluated on using the new `--evaluate-test-split` flag.
-- Now evaluates instruction tuned models with their chat template. This _does_ often
-  result in worse scores, but it is more representative of how the model is used in
-  practice. Further, if a tokeniser has multiple chat templates, then we use the one
-  corresponding to the ISO 639-1 language code of the dataset, if available -
-  otherwise we will just use the default chat template of the tokeniser.
+- Now evaluates instruction tuned models with their chat template. Further, if a
+  tokeniser has multiple chat templates, then we use the one corresponding to the ISO
+  639-1 language code of the dataset, if available (e.g., "en" for English, "is" for
+  Icelandic and so on) - otherwise we will just use the default chat template of the
+  tokeniser.
 
 ### Removed
 - Removed the option to evaluate on the training split, as this is not a common use

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -396,23 +396,16 @@ class LiteLLMModel(BenchmarkModule):
             few_shot_examples = self._extract_few_shot_examples(
                 dataset=dataset, task=task, itr_idx=itr_idx
             )
-            dataset["test"] = dataset["test"].map(
-                partial(
-                    self._apply_few_shot_prompt,
-                    few_shot_examples=few_shot_examples,
-                    task=task,
-                ),
-                batched=True,
-                load_from_cache_file=False,
-                keep_in_memory=True,
-            )
         else:
-            dataset["test"] = dataset["test"].map(
-                partial(self._apply_instruction_prompt, task=task),
-                batched=True,
-                load_from_cache_file=False,
-                keep_in_memory=True,
-            )
+            few_shot_examples = list()
+
+        dataset["test"] = dataset["test"].map(
+            partial(self._apply_prompt, few_shot_examples=few_shot_examples, task=task),
+            batched=True,
+            load_from_cache_file=False,
+            keep_in_memory=True,
+        )
+
         return dataset
 
     def _extract_few_shot_examples(
@@ -524,13 +517,13 @@ class LiteLLMModel(BenchmarkModule):
         random.shuffle(few_shot_examples)
         return few_shot_examples
 
-    def _apply_few_shot_prompt(
+    def _apply_prompt(
         self,
         examples: dict[str, t.Any],
         few_shot_examples: list[dict[str, t.Any]],
         task: Task,
     ) -> dict[str, t.Any]:
-        """Apply few-shot examples to an example.
+        """Apply prompt template to an example, potentially with few-shot examples.
 
         Args:
             examples:
@@ -667,48 +660,4 @@ class LiteLLMModel(BenchmarkModule):
             for new_section in new_sections
         ]
 
-        return examples
-
-    def _apply_instruction_prompt(
-        self, examples: dict[str, t.Any], task: Task
-    ) -> dict[str, t.Any]:
-        """Apply instruction prompts to an example.
-
-        Args:
-            examples:
-                The examples to apply the instruction prompts to.
-            task:
-                The task that is being benchmarked.
-
-        Returns:
-            The example with the instruction prompts applied.
-        """
-        match task.supertask:
-            case "sequence-classification" | "text-to-text" | "token-classification":
-                prompts = [
-                    self.dataset_config.instruction_prompt.format(
-                        text=re.sub(r"\n+", "\n", text).strip()
-                    )
-                    for text in examples["text"]
-                ]
-
-            case "question-answering":
-                prompts = [
-                    self.dataset_config.instruction_prompt.format(
-                        text=re.sub(pattern=r"\n+", repl="\n", string=text).strip(),
-                        question=question.strip(),
-                    )
-                    for (text, question) in zip(
-                        examples["context"], examples["question"]
-                    )
-                ]
-
-            case _:
-                raise NotImplementedError(
-                    f"Unsupported task supertask: {task.supertask}."
-                )
-
-        examples["messages"] = [
-            [dict(role="user", content=prompt)] for prompt in prompts
-        ]
         return examples

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -50,6 +50,7 @@ from ..task_utils import (
 )
 from ..types import ExtractLabelsFunction
 from ..utils import (
+    HiddenPrints,
     clear_memory,
     create_model_cache_dir,
     get_end_of_chat_token_ids,
@@ -507,9 +508,6 @@ class VLLMModel(HuggingFaceEncoderModel):
             raise InvalidModel(
                 f"The model {model_id!r} could not be loaded. The error was {e!r}."
             )
-        except TypeError:
-            breakpoint()
-            pass
 
         model._run_engine = MethodType(_run_engine_with_fixed_progress_bars, model)
         model.config = hf_model_config
@@ -950,14 +948,16 @@ def _run_engine_with_fixed_progress_bars(
 
 def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
-    try:
-        destroy_model_parallel()
-    except ImportError:
-        pass
-    # try:
-    #     destroy_process_group()
-    # except AssertionError:
-    #     pass
-    clear_memory()
-    if ray.is_initialized():
-        ray.shutdown()
+    with HiddenPrints():
+        try:
+            destroy_model_parallel()
+        except ImportError:
+            pass
+        # TEMP: Check if this is needed
+        # try:
+        #     destroy_process_group()
+        # except AssertionError:
+        #     pass
+        clear_memory()
+        if ray.is_initialized():
+            ray.shutdown()

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -645,7 +645,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         Returns:
             The example with the few-shot examples applied.
         """
-        instruction_model = self._tokenizer.chat_template is not None
+        instruction_model = self._tokenizer.chat_template is not None and False  # TEMP
 
         def create_prompt(**kwargs) -> tuple[str, str]:
             """Create a prompt from the given keyword arguments.
@@ -750,8 +750,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                     f"Unsupported task supertask: {task.supertask}."
                 )
 
-        instruction_model = self._tokenizer.chat_template is not None
-        if instruction_model and False:  # TEMP
+        if instruction_model:
             few_shot_messages = [
                 dict(role=role, content=content)
                 for prompt, label in few_shot_sections

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -753,10 +753,10 @@ class VLLMModel(HuggingFaceEncoderModel):
         instruction_model = self._tokenizer.chat_template is not None
         if instruction_model:
             few_shot_messages = [
-                dict(role=role, content=content.split(":", 1)[1].strip())
-                for prompt_label in few_shot_sections
-                for role, content in zip(it.cycle(["user", "assistant"]), prompt_label)
-                if content.split(":", 1)[1].strip() != ""
+                dict(role=role, content=content)
+                for prompt, label in few_shot_sections
+                for role, content in zip(("user", "assistant"), (prompt, label))
+                if label != ""
             ]
 
             messages_list = [

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -115,8 +115,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         self._model: LLM = model
         self._tokenizer: PreTrainedTokenizer = tokenizer
 
-        # TEMP
-        self.instruction_model = self._tokenizer.chat_template is not None and False
+        self.instruction_model = self._tokenizer.chat_template is not None
 
         self.lora_request: LoRARequest | None = None
         if self.model_config.adapter_base_model_id is not None:

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -16,6 +16,7 @@ from types import MethodType
 import torch
 from datasets import DatasetDict
 from huggingface_hub import snapshot_download
+from torch.distributed import destroy_process_group
 from tqdm.auto import tqdm
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer, Trainer
 from urllib3.exceptions import RequestError
@@ -951,11 +952,10 @@ def clear_vllm() -> None:
         destroy_model_parallel()
     except ImportError:
         pass
-    # TEMP: Check if this is needed
-    # try:
-    #     destroy_process_group()
-    # except AssertionError:
-    #     pass
+    try:
+        destroy_process_group()
+    except AssertionError:
+        pass
     clear_memory()
     if ray.is_initialized():
         ray.shutdown()

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -751,7 +751,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 )
 
         instruction_model = self._tokenizer.chat_template is not None
-        if instruction_model:
+        if instruction_model and False:  # TEMP
             few_shot_messages = [
                 dict(role=role, content=content)
                 for prompt, label in few_shot_sections

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -755,7 +755,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             few_shot_messages = [
                 dict(role=role, content=content)
                 for prompt, label in few_shot_sections
-                for role, content in zip(("user", "assistant"), (prompt, label))
+                for role, content in [("user", prompt), ("assistant", label)]
                 if label != ""
             ]
 

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -473,7 +473,6 @@ class VLLMModel(HuggingFaceEncoderModel):
         # Prefer base model ID if the model is an adapter - the adapter will be added on
         # during inference in this case
         model_id = self.model_config.adapter_base_model_id or self.model_config.model_id
-        breakpoint()
 
         try:
             model = LLM(
@@ -491,7 +490,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 quantization=quantization,
                 dtype=dtype,
                 enforce_eager=True,
-                max_logprobs=MAX_LOGPROBS,
+                max_logprobs=MAX_LOGPROBS if self.output_scores else None,
                 # TEMP: Prefix caching isn't supported with sliding window in vLLM yet,
                 # so we disable it for now
                 enable_prefix_caching=False,
@@ -508,6 +507,9 @@ class VLLMModel(HuggingFaceEncoderModel):
             raise InvalidModel(
                 f"The model {model_id!r} could not be loaded. The error was {e!r}."
             )
+        except TypeError:
+            breakpoint()
+            pass
 
         model._run_engine = MethodType(_run_engine_with_fixed_progress_bars, model)
         model.config = hf_model_config

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -671,7 +671,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 label_key = "label" if "label" in kwargs else "target_text"
                 label = kwargs.pop(label_key)
                 label_mapping = self.dataset_config.prompt_label_mapping
-                if label_mapping:
+                if label in label_mapping:
                     label = label_mapping[label]
                 prompt = self.dataset_config.instruction_prompt.format(**kwargs)
                 return prompt, label

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -50,7 +50,6 @@ from ..task_utils import (
 )
 from ..types import ExtractLabelsFunction
 from ..utils import (
-    HiddenPrints,
     clear_memory,
     create_model_cache_dir,
     get_end_of_chat_token_ids,
@@ -948,16 +947,15 @@ def _run_engine_with_fixed_progress_bars(
 
 def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
-    with HiddenPrints():
-        try:
-            destroy_model_parallel()
-        except ImportError:
-            pass
-        # TEMP: Check if this is needed
-        # try:
-        #     destroy_process_group()
-        # except AssertionError:
-        #     pass
-        clear_memory()
-        if ray.is_initialized():
-            ray.shutdown()
+    try:
+        destroy_model_parallel()
+    except ImportError:
+        pass
+    # TEMP: Check if this is needed
+    # try:
+    #     destroy_process_group()
+    # except AssertionError:
+    #     pass
+    clear_memory()
+    if ray.is_initialized():
+        ray.shutdown()

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -56,6 +56,7 @@ from ..utils import (
     create_model_cache_dir,
     get_end_of_chat_token_ids,
     log_once,
+    should_prompts_be_stripped,
 )
 from .hf import HuggingFaceEncoderModel, get_model_repo_info
 
@@ -280,6 +281,13 @@ class VLLMModel(HuggingFaceEncoderModel):
                 prompt if len(prompt) > 0 else self._tokenizer.bos_token
                 for prompt in prompts
             ]
+
+        # Strip the prompts if the model's tokeniser requires it
+        labels_to_be_generated = list(self.dataset_config.prompt_label_mapping.values())
+        if labels_to_be_generated and should_prompts_be_stripped(
+            labels_to_be_generated=labels_to_be_generated, tokenizer=self._tokenizer
+        ):
+            prompts = [prompt.strip() for prompt in prompts]
 
         # Generate sequences using vLLM
         input_is_a_test = len(prompts) == 1 and len(set(prompts[0])) == 1

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -283,9 +283,14 @@ class VLLMModel(HuggingFaceEncoderModel):
             ]
 
         # Strip the prompts if the model's tokeniser requires it
+        instruction_model = self._tokenizer.chat_template is not None
         labels_to_be_generated = list(self.dataset_config.prompt_label_mapping.values())
-        if labels_to_be_generated and should_prompts_be_stripped(
-            labels_to_be_generated=labels_to_be_generated, tokenizer=self._tokenizer
+        if (
+            not instruction_model
+            and len(labels_to_be_generated) > 0
+            and should_prompts_be_stripped(
+                labels_to_be_generated=labels_to_be_generated, tokenizer=self._tokenizer
+            )
         ):
             prompts = [prompt.strip() for prompt in prompts]
 

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -753,7 +753,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
             if self.dataset_config.prompt_prefix:
                 few_shot_messages[0]["content"] = (
-                    self.dataset_config.prompt_prefix
+                    self.dataset_config.instruction_prompt
                     + "\n\n"
                     + few_shot_messages[0]["content"]
                 )

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -670,6 +670,9 @@ class VLLMModel(HuggingFaceEncoderModel):
             if instruction_model:
                 label_key = "label" if "label" in kwargs else "target_text"
                 label = kwargs.pop(label_key)
+                label_mapping = self.dataset_config.prompt_label_mapping
+                if label_mapping:
+                    label = label_mapping[label]
                 prompt = self.dataset_config.instruction_prompt.format(**kwargs)
                 return prompt, label
             else:

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -818,6 +818,11 @@ class VLLMModel(HuggingFaceEncoderModel):
         if hasattr(self, "_model"):
             del self._model
         del self
+        try:
+            destroy_process_group()
+        except AssertionError:
+            pass
+        clear_vllm()
 
     @cached_property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
@@ -950,10 +955,6 @@ def clear_vllm() -> None:
     try:
         destroy_model_parallel()
     except ImportError:
-        pass
-    try:
-        destroy_process_group()
-    except AssertionError:
         pass
     clear_memory()
     if ray.is_initialized():

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -953,6 +953,7 @@ def clear_vllm() -> None:
     except ImportError:
         pass
     try:
+        breakpoint()
         destroy_process_group()
     except AssertionError:
         pass

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -818,7 +818,6 @@ class VLLMModel(HuggingFaceEncoderModel):
         if hasattr(self, "_model"):
             del self._model
         del self
-        clear_vllm()
 
     @cached_property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
@@ -953,7 +952,6 @@ def clear_vllm() -> None:
     except ImportError:
         pass
     try:
-        breakpoint()
         destroy_process_group()
     except AssertionError:
         pass

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -799,8 +799,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                 for messages in messages_list
             ]
 
-            breakpoint()
-
             examples["text"] = texts
 
         else:

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -473,6 +473,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         # Prefer base model ID if the model is an adapter - the adapter will be added on
         # during inference in this case
         model_id = self.model_config.adapter_base_model_id or self.model_config.model_id
+        breakpoint()
 
         try:
             model = LLM(

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -654,7 +654,7 @@ class VLLMModel(HuggingFaceEncoderModel):
         Returns:
             The example with the few-shot examples applied.
         """
-        instruction_model = self._tokenizer.chat_template is not None and False  # TEMP
+        instruction_model = self._tokenizer.chat_template is not None
 
         def create_prompt(**kwargs) -> tuple[str, str]:
             """Create a prompt from the given keyword arguments.
@@ -764,7 +764,6 @@ class VLLMModel(HuggingFaceEncoderModel):
                 dict(role=role, content=content)
                 for prompt, label in few_shot_sections
                 for role, content in [("user", prompt), ("assistant", label)]
-                if label != ""
             ]
 
             messages_list = [
@@ -797,6 +796,8 @@ class VLLMModel(HuggingFaceEncoderModel):
                 )
                 for messages in messages_list
             ]
+
+            breakpoint()
 
             examples["text"] = texts
 

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -986,8 +986,11 @@ def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
     try:
         destroy_model_parallel()
-        destroy_process_group()
     except ImportError:
+        pass
+    try:
+        destroy_process_group()
+    except AssertionError:
         pass
     clear_memory()
     if ray.is_initialized():

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -16,7 +16,6 @@ from types import MethodType
 import torch
 from datasets import DatasetDict
 from huggingface_hub import snapshot_download
-from torch.distributed import destroy_process_group
 from tqdm.auto import tqdm
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer, Trainer
 from urllib3.exceptions import RequestError
@@ -813,16 +812,16 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         return examples
 
-    def __del__(self) -> None:
-        """Clear the GPU memory used by the model, and remove the model itself."""
-        if hasattr(self, "_model"):
-            del self._model
-        del self
-        try:
-            destroy_process_group()
-        except AssertionError:
-            pass
-        clear_vllm()
+    # def __del__(self) -> None:
+    #     """Clear the GPU memory used by the model, and remove the model itself."""
+    #     if hasattr(self, "_model"):
+    #         del self._model
+    #     del self
+    #     try:
+    #         destroy_process_group()
+    #     except AssertionError:
+    #         pass
+    #     clear_vllm()
 
     @cached_property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -812,17 +812,6 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         return examples
 
-    # def __del__(self) -> None:
-    #     """Clear the GPU memory used by the model, and remove the model itself."""
-    #     if hasattr(self, "_model"):
-    #         del self._model
-    #     del self
-    #     try:
-    #         destroy_process_group()
-    #     except AssertionError:
-    #         pass
-    #     clear_vllm()
-
     @cached_property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
         """The data collator used to prepare samples during finetuning.
@@ -953,7 +942,7 @@ def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
     try:
         destroy_model_parallel()
-    except (ImportError, ValueError):
+    except ImportError:
         pass
     clear_memory()
     if ray.is_initialized():

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -16,7 +16,6 @@ from types import MethodType
 import torch
 from datasets import DatasetDict
 from huggingface_hub import snapshot_download
-from torch.distributed import destroy_process_group
 from tqdm.auto import tqdm
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer, Trainer
 from urllib3.exceptions import RequestError
@@ -496,6 +495,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 enable_prefix_caching=False,
                 enable_lora=self.model_config.adapter_base_model_id is not None,
                 max_lora_rank=256,
+                guided_decoding_backend="outlines",
             )
         except ValueError as e:
             if "trust_remote_code" in str(e):
@@ -954,10 +954,10 @@ def clear_vllm() -> None:
         destroy_model_parallel()
     except ImportError:
         pass
-    try:
-        destroy_process_group()
-    except AssertionError:
-        pass
+    # try:
+    #     destroy_process_group()
+    # except AssertionError:
+    #     pass
     clear_memory()
     if ray.is_initialized():
         ray.shutdown()

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -671,8 +671,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 label_key = "label" if "label" in kwargs else "target_text"
                 label = kwargs.pop(label_key)
                 label_mapping = self.dataset_config.prompt_label_mapping
-                if label in label_mapping:
-                    label = label_mapping[label]
+                label = label_mapping.get(label, label)
                 prompt = self.dataset_config.instruction_prompt.format(**kwargs)
                 return prompt, label
             else:

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -954,7 +954,7 @@ def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
     try:
         destroy_model_parallel()
-    except ImportError:
+    except (ImportError, ValueError):
         pass
     clear_memory()
     if ray.is_initialized():

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -17,6 +17,7 @@ from types import MethodType
 import torch
 from datasets import DatasetDict
 from huggingface_hub import snapshot_download
+from torch.distributed import destroy_process_group
 from tqdm.auto import tqdm
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizer, Trainer
 from urllib3.exceptions import RequestError
@@ -985,6 +986,7 @@ def clear_vllm() -> None:
     """Clear the GPU memory used by the vLLM model, enabling re-initialisation."""
     try:
         destroy_model_parallel()
+        destroy_process_group()
     except ImportError:
         pass
     clear_memory()

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -11,7 +11,6 @@ from shutil import rmtree
 from time import sleep
 
 from .benchmark_config_factory import build_benchmark_config
-from .constants import GENERATIVE_MODEL_TASKS
 from .data_loading import load_data
 from .data_models import BenchmarkConfigParams, BenchmarkResult
 from .dataset_configs import get_all_dataset_configs
@@ -520,11 +519,6 @@ class Benchmarker:
         model: BenchmarkModule | None = None
         while True:
             try:
-                model_config = get_model_config(
-                    model_id=model_config.model_id,
-                    benchmark_config=self.benchmark_config,
-                )
-
                 # Set random seeds to enforce reproducibility of the randomly
                 # initialised weights
                 rng = enforce_reproducibility(framework=model_config.framework)
@@ -537,15 +531,6 @@ class Benchmarker:
                         benchmark_config=benchmark_config,
                     )
                 assert model is not None
-
-                # This happens when a local model is used, as we cannot fetch the model
-                # metadata. Note that this is only the case if the model type is not any
-                # of the ones hardcoded in `local.py`
-                if model_config.task == "unknown":
-                    if model.is_generative:
-                        model_config.task = GENERATIVE_MODEL_TASKS[0]
-                    else:
-                        model_config.task = "fill-mask"
 
                 if dataset_config.task == SPEED:
                     scores = benchmark_speed(

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -157,6 +157,8 @@ def generate_single_iteration(
             if single_sample_batch:
                 batch = {key: [value] for key, value in batch.items()}
 
+            breakpoint()
+
             model_output = model.generate(inputs=batch)
             extracted_labels = model.extract_labels_from_generation(
                 input_batch=batch, model_output=model_output

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -149,11 +149,8 @@ def generate_single_iteration(
             assert isinstance(batch, dict)
 
             single_sample_batch = (
-                "text" in batch
-                and isinstance(batch["text"], str)
-                or "messages" in batch
-                and isinstance(batch["messages"][0], dict)
-            )
+                "text" in batch and isinstance(batch["text"], str)
+            ) or ("messages" in batch and isinstance(batch["messages"][0], dict))
             if single_sample_batch:
                 batch = {key: [value] for key, value in batch.items()}
 

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -154,6 +154,7 @@ def generate_single_iteration(
             if single_sample_batch:
                 batch = {key: [value] for key, value in batch.items()}
 
+            breakpoint()
             model_output = model.generate(inputs=batch)
             extracted_labels = model.extract_labels_from_generation(
                 input_batch=batch, model_output=model_output

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -154,8 +154,6 @@ def generate_single_iteration(
             if single_sample_batch:
                 batch = {key: [value] for key, value in batch.items()}
 
-            breakpoint()
-
             model_output = model.generate(inputs=batch)
             extracted_labels = model.extract_labels_from_generation(
                 input_batch=batch, model_output=model_output

--- a/src/scandeval/generation.py
+++ b/src/scandeval/generation.py
@@ -154,7 +154,6 @@ def generate_single_iteration(
             if single_sample_batch:
                 batch = {key: [value] for key, value in batch.items()}
 
-            breakpoint()
             model_output = model.generate(inputs=batch)
             extracted_labels = model.extract_labels_from_generation(
                 input_batch=batch, model_output=model_output

--- a/src/scandeval/utils.py
+++ b/src/scandeval/utils.py
@@ -381,6 +381,7 @@ def should_prompts_be_stripped(
     return strip_prompts
 
 
+# TODO: This is currently not used - maybe remove.
 def should_prefix_space_be_added_to_labels(
     labels_to_be_generated: list[str], tokenizer: "PreTrainedTokenizer"
 ) -> bool:


### PR DESCRIPTION
- Changes the prompt application flow:
  - If the model is not instruction tuned, then apply regular prompt template and strip prompts if necessary.
  - Otherwise, apply chat template.
- Use universal `_apply_prompt` method, both for few-shot and zero-shot.
- Also avoid warning when evaluation finishes by calling `destroy_process_group` in `clear_vllm`.