### PR TITLE
Fix/api base and version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Added the `api_version` argument, mimicking the LiteLLM API.
 
+### Changed
+- Changed the `base_url` argument to `api_base`, to mimic the LiteLLM API.
+
+### Fixed
+- Now correctly uses the `api_base` argument when evaluating models with the LiteLLM
+  API.
 
 
 ## [v14.0.0] - 2024-12-11

--- a/src/scandeval/benchmark_config_factory.py
+++ b/src/scandeval/benchmark_config_factory.py
@@ -44,7 +44,8 @@ def build_benchmark_config(
     evaluate_test_split: bool,
     few_shot: bool,
     num_iterations: int,
-    base_url: str | None,
+    api_base: str | None,
+    api_version: str | None,
     debug: bool,
     run_with_cli: bool,
     first_time: bool = False,
@@ -107,9 +108,11 @@ def build_benchmark_config(
             Whether to use few-shot learning for the models.
         num_iterations:
             The number of iterations each model should be evaluated for.
-        base_url:
+        api_base:
             The base URL for a given inference API. Only relevant if `model` refers to a
             model on an inference API.
+        api_version:
+            The version of the API to use for a given inference API.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -187,7 +190,8 @@ def build_benchmark_config(
         evaluate_test_split=evaluate_test_split,
         few_shot=few_shot,
         num_iterations=num_iterations,
-        base_url=base_url,
+        api_base=api_base,
+        api_version=api_version,
         debug=debug,
         run_with_cli=run_with_cli,
     )

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -681,14 +681,14 @@ def get_model_repo_info(
 
 
 def load_tokenizer(
-    model: "PreTrainedModel", model_id: str, trust_remote_code: bool
+    model: "PreTrainedModel | None", model_id: str, trust_remote_code: bool
 ) -> "PreTrainedTokenizer":
     """Load the tokenizer.
 
     Args:
         model:
             The model, which is used to determine whether to add a prefix space to
-            the tokens.
+            the tokens. Can be None.
         model_id:
             The model identifier. Used for logging.
         trust_remote_code:
@@ -705,12 +705,15 @@ def load_tokenizer(
         truncation_side="right",
     )
 
-    # If the model is a subclass of a certain model types then we have to add a
-    # prefix space to the tokens, by the way the model is constructed.
-    prefix_models = ["Roberta", "GPT", "Deberta"]
-    add_prefix = any(model_type in type(model).__name__ for model_type in prefix_models)
-    if add_prefix:
-        loading_kwargs["add_prefix_space"] = True
+    # If the model is a subclass of a certain model types then we have to add a prefix
+    # space to the tokens, by the way the model is constructed.
+    if model is not None:
+        prefix_models = ["Roberta", "GPT", "Deberta"]
+        add_prefix = any(
+            model_type in type(model).__name__ for model_type in prefix_models
+        )
+        if add_prefix:
+            loading_kwargs["add_prefix_space"] = True
 
     while True:
         try:

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -122,6 +122,8 @@ class LiteLLMModel(BenchmarkModule):
         generation_kwargs: dict[str, t.Any] = dict(
             model=self.model_config.model_id,
             max_completion_tokens=self.dataset_config.max_generated_tokens,
+            max_new_tokens=self.dataset_config.max_generated_tokens,
+            max_tokens=5000,
             stop=["\n\n"],
             temperature=0.0,
             seed=4242,

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -125,6 +125,9 @@ class LiteLLMModel(BenchmarkModule):
             stop=["\n\n"],
             temperature=0.0,
             seed=4242,
+            api_key=self.benchmark_config.api_key,
+            api_base=self.benchmark_config.api_base,
+            api_version=self.benchmark_config.api_version,
         )
 
         if self.dataset_config.task.supertask in SUPERTASKS_USING_LOGPROBS:
@@ -136,15 +139,6 @@ class LiteLLMModel(BenchmarkModule):
                 "json" in messages[0]["content"]
             ), "Prompt must contain 'json' for JSON tasks."
             generation_kwargs["response_format"] = dict(type="json_object")
-
-        if self.benchmark_config.api_key is not None:
-            generation_kwargs["api_key"] = self.benchmark_config.api_key
-
-        if self.benchmark_config.api_base is not None:
-            generation_kwargs["api_base"] = self.benchmark_config.api_base
-
-        if self.benchmark_config.api_version is not None:
-            generation_kwargs["api_version"] = self.benchmark_config.api_version
 
         # This drops generation kwargs that are not supported by the model
         litellm.drop_params = True
@@ -308,7 +302,12 @@ class LiteLLMModel(BenchmarkModule):
 
         try:
             litellm.completion(
-                messages=[dict(role="user", content="X")], model=model_id, max_tokens=1
+                messages=[dict(role="user", content="X")],
+                model=model_id,
+                max_tokens=1,
+                api_key=benchmark_config.api_key,
+                api_base=benchmark_config.api_base,
+                api_version=benchmark_config.api_version,
             )
             return True
         except (BadRequestError, NotFoundError):

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -119,11 +119,9 @@ class LiteLLMModel(BenchmarkModule):
         ), "API models only support single-sample batching."
         messages = inputs["messages"][0]
 
-        max_input_and_output_tokens = 5_000 + self.dataset_config.max_generated_tokens
         generation_kwargs: dict[str, t.Any] = dict(
             model=self.model_config.model_id,
-            max_tokens=max_input_and_output_tokens,
-            max_new_tokens=self.dataset_config.max_generated_tokens,
+            max_completion_tokens=self.dataset_config.max_generated_tokens,
             stop=["\n\n"],
             temperature=0.0,
             seed=4242,

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -183,7 +183,8 @@ class LiteLLMModel(BenchmarkModule):
         assert isinstance(model_response, ModelResponse)
         model_response_choices = model_response.choices[0]
         assert isinstance(model_response_choices, litellm.Choices)
-        generation_output = model_response_choices.message["content"].strip()
+        generation_output = model_response_choices.message["content"] or ""
+        generation_output = generation_output.strip()
 
         # Structure the model output as a GenerativeModelOutput object
         model_output = GenerativeModelOutput(sequences=[generation_output])

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -137,6 +137,15 @@ class LiteLLMModel(BenchmarkModule):
             ), "Prompt must contain 'json' for JSON tasks."
             generation_kwargs["response_format"] = dict(type="json_object")
 
+        if self.benchmark_config.api_key is not None:
+            generation_kwargs["api_key"] = self.benchmark_config.api_key
+
+        if self.benchmark_config.api_base is not None:
+            generation_kwargs["api_base"] = self.benchmark_config.api_base
+
+        if self.benchmark_config.api_version is not None:
+            generation_kwargs["api_version"] = self.benchmark_config.api_version
+
         # This drops generation kwargs that are not supported by the model
         litellm.drop_params = True
 

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -121,9 +121,7 @@ class LiteLLMModel(BenchmarkModule):
 
         generation_kwargs: dict[str, t.Any] = dict(
             model=self.model_config.model_id,
-            max_completion_tokens=self.dataset_config.max_generated_tokens,
-            max_new_tokens=self.dataset_config.max_generated_tokens,
-            max_tokens=5000,
+            max_tokens=self.dataset_config.max_generated_tokens,
             stop=["\n\n"],
             temperature=0.0,
             seed=4242,

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -303,6 +303,7 @@ class LiteLLMModel(BenchmarkModule):
         num_attempts = 10
         for _ in range(num_attempts):
             try:
+                breakpoint()
                 litellm.completion(
                     messages=[dict(role="user", content="X")],
                     model=model_id,
@@ -313,7 +314,6 @@ class LiteLLMModel(BenchmarkModule):
                 )
                 return True
             except APIError as e:
-                breakpoint()
                 if "'503 Service Unavailable" not in str(e):
                     raise e
                 logger.warning(

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -311,6 +311,7 @@ class LiteLLMModel(BenchmarkModule):
             )
             return True
         except (BadRequestError, NotFoundError):
+            breakpoint()
             candidate_models = [
                 candidate_model_id
                 for candidate_model_id in litellm.model_list

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -303,7 +303,6 @@ class LiteLLMModel(BenchmarkModule):
         num_attempts = 10
         for _ in range(num_attempts):
             try:
-                breakpoint()
                 litellm.completion(
                     messages=[dict(role="user", content="X")],
                     model=model_id,

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -119,9 +119,11 @@ class LiteLLMModel(BenchmarkModule):
         ), "API models only support single-sample batching."
         messages = inputs["messages"][0]
 
+        max_input_and_output_tokens = 5_000 + self.dataset_config.max_generated_tokens
         generation_kwargs: dict[str, t.Any] = dict(
             model=self.model_config.model_id,
-            max_tokens=self.dataset_config.max_generated_tokens,
+            max_tokens=max_input_and_output_tokens,
+            max_new_tokens=self.dataset_config.max_generated_tokens,
             stop=["\n\n"],
             temperature=0.0,
             seed=4242,

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -313,6 +313,7 @@ class LiteLLMModel(BenchmarkModule):
                 )
                 return True
             except APIError as e:
+                breakpoint()
                 if "'503 Service Unavailable" not in str(e):
                     raise e
                 logger.warning(

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -359,6 +359,13 @@ class VLLMModel(HuggingFaceEncoderModel):
             Whether the model exists, or an error describing why we cannot check
             whether the model exists.
         """
+        using_api = (
+            benchmark_config.api_base is not None
+            or benchmark_config.api_version is not None
+        )
+        if using_api:
+            return False
+
         model_id, revision = (
             model_id.split("@") if "@" in model_id else (model_id, "main")
         )

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -76,7 +76,8 @@ class Benchmarker:
         evaluate_test_split: bool = False,
         few_shot: bool = True,
         num_iterations: int = 10,
-        base_url: str | None = None,
+        api_base: str | None = None,
+        api_version: str | None = None,
         debug: bool = False,
         run_with_cli: bool = False,
     ) -> None:
@@ -149,9 +150,11 @@ class Benchmarker:
                 The number of times each model should be evaluated. This is only meant
                 to be used for power users, and scores will not be allowed on the
                 leaderboards if this is changed. Defaults to 10.
-            base_url:
+            api_base:
                 The base URL for a given inference API. Only relevant if `model` refers
                 to a model on an inference API. Defaults to None.
+            api_version:
+                The version of the API to use. Defaults to None.
             debug:
                 Whether to output debug information. Defaults to False.
             run_with_cli:
@@ -188,7 +191,8 @@ class Benchmarker:
             evaluate_test_split=evaluate_test_split,
             few_shot=few_shot,
             num_iterations=num_iterations,
-            base_url=base_url,
+            api_base=api_base,
+            api_version=api_version,
             debug=debug,
             run_with_cli=run_with_cli,
         )

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -196,11 +196,18 @@ from .tasks import get_all_tasks
     is changed.""",
 )
 @click.option(
-    "--base-url",
+    "--api-base",
     default=None,
     show_default=True,
     help="The base URL for a given inference API. Only relevant if `model` refers to a "
     "model on an inference API.",
+)
+@click.option(
+    "--api-version",
+    default=None,
+    show_default=True,
+    help="The version of the API to use. Only relevant if `model` refers to a model on "
+    "an inference API.",
 )
 @click.option(
     "--debug/--no-debug",
@@ -234,7 +241,8 @@ def benchmark(
     evaluate_test_split: bool,
     few_shot: bool,
     num_iterations: int,
-    base_url: str | None,
+    api_base: str | None,
+    api_version: str | None,
     debug: bool,
 ) -> None:
     """Benchmark pretrained language models on language tasks."""
@@ -270,7 +278,8 @@ def benchmark(
         evaluate_test_split=evaluate_test_split,
         few_shot=few_shot,
         num_iterations=num_iterations,
-        base_url=base_url,
+        api_base=api_base,
+        api_version=api_version,
         debug=debug,
         run_with_cli=True,
     )

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -203,6 +203,13 @@ from .tasks import get_all_tasks
     "model on an inference API.",
 )
 @click.option(
+    "--api-version",
+    default=None,
+    show_default=True,
+    help="The version of the API to use. Only relevant if `model` refers to a model on "
+    "an inference API.",
+)
+@click.option(
     "--debug/--no-debug",
     default=False,
     show_default=True,

--- a/src/scandeval/cli.py
+++ b/src/scandeval/cli.py
@@ -203,13 +203,6 @@ from .tasks import get_all_tasks
     "model on an inference API.",
 )
 @click.option(
-    "--api-version",
-    default=None,
-    show_default=True,
-    help="The version of the API to use. Only relevant if `model` refers to a model on "
-    "an inference API.",
-)
-@click.option(
     "--debug/--no-debug",
     default=False,
     show_default=True,

--- a/src/scandeval/data_models.py
+++ b/src/scandeval/data_models.py
@@ -149,9 +149,12 @@ class BenchmarkConfig:
             if the model is generative.
         num_iterations:
             The number of iterations each model should be evaluated for.
-        base_url:
+        api_base:
             The base URL for a given inference API. Only relevant if `model` refers to a
             model on an inference API.
+        api_version:
+            The version of the API to use. Only relevant if `model` refers to a model on
+            an inference API.
         debug:
             Whether to run the benchmark in debug mode.
         run_with_cli:
@@ -179,7 +182,8 @@ class BenchmarkConfig:
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
-    base_url: str | None
+    api_base: str | None
+    api_version: str | None
     debug: bool
     run_with_cli: bool
 
@@ -211,7 +215,8 @@ class BenchmarkConfigParams(pydantic.BaseModel):
     evaluate_test_split: bool
     few_shot: bool
     num_iterations: int
-    base_url: str | None
+    api_base: str | None
+    api_version: str | None
     debug: bool
     run_with_cli: bool
 

--- a/src/scandeval/human_evaluation.py
+++ b/src/scandeval/human_evaluation.py
@@ -272,7 +272,8 @@ class HumanEvaluator:
             evaluate_test_split=False,
             few_shot=True,
             num_iterations=iteration + 1,
-            base_url=None,
+            api_base=None,
+            api_version=None,
             debug=False,
             run_with_cli=True,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,8 @@ def benchmark_config(auth, device) -> Generator[BenchmarkConfig, None, None]:
         evaluate_test_split=False,
         few_shot=True,
         num_iterations=1,
-        base_url=None,
+        api_base=None,
+        api_version=None,
         debug=False,
         run_with_cli=True,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,8 @@ def test_cli_param_names(params):
         "evaluate_test_split",
         "few_shot",
         "num_iterations",
-        "base_url",
+        "api_base",
+        "api_version",
         "debug",
         "help",
     }
@@ -73,6 +74,7 @@ def test_cli_param_types(params):
     assert params["evaluate_test_split"] == BOOL
     assert params["few_shot"] == BOOL
     assert params["num_iterations"] == INT
-    assert params["base_url"] == STRING
+    assert params["api_base"] == STRING
+    assert params["api_version"] == STRING
     assert params["debug"] == BOOL
     assert params["help"] == BOOL


### PR DESCRIPTION
### Added
- Added the `api_version` argument, mimicking the LiteLLM API.

### Changed
- Changed the `base_url` argument to `api_base`, to mimic the LiteLLM API.

### Fixed
- Now correctly uses the `api_base` argument when evaluating models with the LiteLLM
  API.