### PR TITLE
Fix/speed benchmark

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      #- id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      #- id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   tuned.
 - LiteLLM models now uses the instruction prompt, also when few-shot evaluating, just
   like all vLLM models.
-- Now catches `ServiceUnavailableError` and `Timeout` LiteLLM exceptions when evaluating
-  API models, and retries the evaluation after a short delay.
+- Now catches more LiteLLM exceptions when evaluating API models, and retries the
+  evaluation after a short delay if the exception is due to a temporary issue.
 
 
 ## [v14.0.1] - 2024-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   tuned.
 - LiteLLM models now uses the instruction prompt, also when few-shot evaluating, just
   like all vLLM models.
-- Now catches `ServiceUnavailableError` when evaluating API models, and retries the
-  evaluation after a short delay.
+- Now catches `ServiceUnavailableError` and `Timeout` LiteLLM exceptions when evaluating
+  API models, and retries the evaluation after a short delay.
 
 
 ## [v14.0.1] - 2024-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed a bug with the speed benchmark for vLLM models, when the model is instruction
   tuned.
+- LiteLLM models now uses the instruction prompt, also when few-shot evaluating, just
+  like all vLLM models.
 
 
 ## [v14.0.1] - 2024-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   tuned.
 - LiteLLM models now uses the instruction prompt, also when few-shot evaluating, just
   like all vLLM models.
+- Now catches `ServiceUnavailableError` when evaluating API models, and retries the
+  evaluation after a short delay.
 
 
 ## [v14.0.1] - 2024-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- Fixed a bug with the speed benchmark for vLLM models, when the model is instruction
+  tuned.
 
 
 ## [v14.0.1] - 2024-12-11

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -21,6 +21,7 @@ from litellm.exceptions import (
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    ServiceUnavailableError,
 )
 from litellm.types.utils import ModelResponse
 from requests.exceptions import RequestException
@@ -177,7 +178,10 @@ class LiteLLMModel(BenchmarkModule):
                     raise InvalidBenchmark(
                         f"Failed to generate text. The error message was: {e}"
                     )
-                sleep(1)
+                sleep(5)
+                continue
+            except ServiceUnavailableError:
+                sleep(5)
                 continue
             except AuthenticationError:
                 raise NeedsAdditionalArgument(

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -171,12 +171,17 @@ class LiteLLMModel(BenchmarkModule):
                         f"Failed to generate text. The error message was: {e}"
                     )
                 generation_kwargs["stop"] = None
-            except (ServiceUnavailableError, APIConnectionError, InternalServerError):
+            except (
+                Timeout,
+                ServiceUnavailableError,
+                APIConnectionError,
+                InternalServerError,
+            ):
                 logger.debug(
                     "Service temporarily unavailable. Retrying in 5 seconds..."
                 )
                 sleep(5)
-            except (Timeout, APIError) as e:
+            except APIError as e:
                 raise InvalidBenchmark(
                     f"Failed to generate text. The error message was: {e}"
                 )

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -206,6 +206,7 @@ class LiteLLMModel(BenchmarkModule):
             ]
             model_output.scores = [logprobs_list]
 
+        breakpoint()
         return model_output
 
     @cached_property

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -171,15 +171,7 @@ class LiteLLMModel(BenchmarkModule):
                         f"Failed to generate text. The error message was: {e}"
                     )
                 generation_kwargs["stop"] = None
-            except (
-                ServiceUnavailableError,
-                APIConnectionError,
-                InternalServerError,
-            ) as e:
-                if "overloaded" not in str(e).lower():
-                    raise InvalidBenchmark(
-                        f"Failed to generate text. The error message was: {e}"
-                    )
+            except (ServiceUnavailableError, APIConnectionError, InternalServerError):
                 logger.debug(
                     "Service temporarily unavailable. Retrying in 5 seconds..."
                 )

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -724,40 +724,48 @@ class LiteLLMModel(BenchmarkModule):
             The example with the few-shot examples applied.
         """
 
-        def split_section(section: str) -> tuple[str, str]:
-            """Split a section of the prompt to user and assistant messages."""
-            user_part = "\n".join(section.split("\n")[:-1])
-            assistant_part = section.split("\n")[-1]
-            return user_part, assistant_part
+        def create_prompt(**kwargs) -> tuple[str, str]:
+            """Create a prompt from the given keyword arguments.
+
+            Args:
+                kwargs:
+                    The keyword arguments to use in the prompt.
+
+            Returns:
+                A pair (prompt, label), where "label" is an empty string if the model is
+                not instruction tuned (as in this case it is included in the prompt).
+            """
+            label_key = "label" if "label" in kwargs else "target_text"
+            label = kwargs.pop(label_key)
+            label_mapping = self.dataset_config.prompt_label_mapping
+            label = label_mapping.get(label, label)
+            prompt = self.dataset_config.instruction_prompt.format(**kwargs)
+            return prompt, label
 
         match task.supertask:
             case "sequence-classification":
                 few_shot_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=example["text"].replace("\n", " ").strip(),
                         label=example["label"].replace("\n", " ").strip(),
                     )
                     for example in few_shot_examples
                 ]
                 new_sections = [
-                    self.dataset_config.prompt_template.format(
-                        text=text.replace("\n", " ").strip(), label=""
-                    )
+                    create_prompt(text=text.replace("\n", " ").strip(), label="")
                     for text in examples["text"]
                 ]
 
             case "text-to-text":
                 few_shot_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=example["text"].replace("\n", " ").strip(),
                         target_text=example["target_text"].replace("\n", " ").strip(),
                     )
                     for example in few_shot_examples
                 ]
                 new_sections = [
-                    self.dataset_config.prompt_template.format(
-                        text=text.replace("\n", " ").strip(), target_text=""
-                    )
+                    create_prompt(text=text.replace("\n", " ").strip(), target_text="")
                     for text in examples["text"]
                 ]
 
@@ -780,14 +788,14 @@ class LiteLLMModel(BenchmarkModule):
                     return json.dumps(labels, ensure_ascii=False)
 
                 few_shot_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=" ".join(example["tokens"]).replace("\n", " ").strip(),
                         label=create_label(example=example),
                     )
                     for example in few_shot_examples
                 ]
                 new_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=" ".join(tokens).replace("\n", " ").strip(), label=""
                     )
                     for tokens in examples["tokens"]
@@ -795,7 +803,7 @@ class LiteLLMModel(BenchmarkModule):
 
             case "question-answering":
                 few_shot_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=example["context"].replace("\n", " ").strip(),
                         question=example["question"].replace("\n", " ").strip(),
                         label=example["answers"]["text"][0].replace("\n", " "),
@@ -803,7 +811,7 @@ class LiteLLMModel(BenchmarkModule):
                     for example in few_shot_examples
                 ]
                 new_sections = [
-                    self.dataset_config.prompt_template.format(
+                    create_prompt(
                         text=context.replace("\n", " ").strip(),
                         question=question.replace("\n", " ").strip(),
                         label="",
@@ -819,32 +827,15 @@ class LiteLLMModel(BenchmarkModule):
                 )
 
         few_shot_messages = [
-            dict(role=role, content=content.split(":", 1)[1].strip())
-            for section in few_shot_sections
-            for role, content in zip(
-                it.cycle(["user", "assistant"]), split_section(section=section)
-            )
-            if content.split(":", 1)[1].strip() != ""
+            dict(role=role, content=content)
+            for prompt, label in few_shot_sections
+            for role, content in [("user", prompt), ("assistant", label)]
         ]
 
-        if self.dataset_config.prompt_prefix:
-            few_shot_messages[0]["content"] = (
-                self.dataset_config.prompt_prefix
-                + "\n\n"
-                + few_shot_messages[0]["content"]
-            )
-
-        examples["messages"] = [
-            few_shot_messages
-            + [
-                dict(
-                    role="user",
-                    content=split_section(section=new_section)[0]
-                    .split(":", 1)[1]
-                    .strip(),
-                )
-            ]
-            for new_section in new_sections
+        messages_list = [
+            few_shot_messages + [dict(role="user", content=prompt)]
+            for prompt, _ in new_sections
         ]
 
+        examples["messages"] = messages_list
         return examples

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -206,7 +206,6 @@ class LiteLLMModel(BenchmarkModule):
             ]
             model_output.scores = [logprobs_list]
 
-        breakpoint()
         return model_output
 
     @cached_property

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -85,12 +85,12 @@ def benchmark_speed_single_iteration(
         }
         pytorch_model(**inputs)
 
-    if isinstance(model, HuggingFaceEncoderModel):
-        predict = encoder_predict
+    if isinstance(model, VLLMModel):
+        predict = generate_prompt_predict
     elif isinstance(model, LiteLLMModel):
         predict = generate_messages_predict
-    elif isinstance(model, VLLMModel):
-        predict = generate_prompt_predict
+    elif isinstance(model, HuggingFaceEncoderModel):
+        predict = encoder_predict
     else:
         raise ValueError(f"Model type {model} not supported for speed benchmark")
 

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -72,7 +72,7 @@ def benchmark_speed_single_iteration(
         model.generate(inputs=dict(messages=[[dict(role="user", content=doc)]]))
 
     def generate_prompt_predict(doc: str) -> None:
-        model.generate(inputs=dict(prompt=[doc]))
+        model.generate(inputs=dict(text=[doc]))
 
     def encoder_predict(doc: str) -> None:
         tokenizer = model.get_tokenizer()
@@ -90,10 +90,7 @@ def benchmark_speed_single_iteration(
     elif isinstance(model, LiteLLMModel):
         predict = generate_messages_predict
     elif isinstance(model, VLLMModel):
-        if model.instruction_model:
-            predict = generate_messages_predict
-        else:
-            predict = generate_prompt_predict
+        predict = generate_prompt_predict
     else:
         raise ValueError(f"Model type {model} not supported for speed benchmark")
 

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -1,8 +1,6 @@
 """Benchmarking model inference speed."""
 
-import collections.abc as c
 import logging
-import typing as t
 
 import pyinfer
 from tqdm.auto import tqdm
@@ -87,12 +85,17 @@ def benchmark_speed_single_iteration(
         }
         pytorch_model(**inputs)
 
-    predict_fn_mapping: dict[t.Type[BenchmarkModule], c.Callable[[str], None]] = {
-        HuggingFaceEncoderModel: encoder_predict,
-        LiteLLMModel: generate_messages_predict,
-        VLLMModel: generate_prompt_predict,
-    }
-    predict = predict_fn_mapping[type(model)]
+    if isinstance(model, HuggingFaceEncoderModel):
+        predict = encoder_predict
+    elif isinstance(model, LiteLLMModel):
+        predict = generate_messages_predict
+    elif isinstance(model, VLLMModel):
+        if model.instruction_model:
+            predict = generate_messages_predict
+        else:
+            predict = generate_prompt_predict
+    else:
+        raise ValueError(f"Model type {model} not supported for speed benchmark")
 
     try:
         # Do a warmup run, as the first run is always slower


### PR DESCRIPTION
### Fixed
- Fixed a bug with the speed benchmark for vLLM models, when the model is instruction
  tuned.
- LiteLLM models now uses the instruction prompt, also when few-shot evaluating, just
  like all vLLM models.
- Now catches more LiteLLM exceptions when evaluating API models, and retries the
  evaluation after a short delay if the exception is due to a temporary issue.