### PR TITLE
Fix/use ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Model cache was not working properly with zero-shot models, meaning that redundant
   generations were made. This has been fixed now, which also makes the zero-shot
   evaluation much faster.
+- Use `ray` as distributed executor backend for vLLM if more than one GPU is available,
+  which fixes an error when using multiple GPUs with vLLM.
 
 
 ## [v14.0.3] - 2024-12-14

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -513,7 +513,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 trust_remote_code=self.benchmark_config.trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
-                distributed_executor_backend="ray",  # TEMP?
+                distributed_executor_backend="ray",
                 tensor_parallel_size=torch.cuda.device_count(),
                 disable_custom_all_reduce=True,
                 quantization=quantization,

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -503,6 +503,8 @@ class VLLMModel(HuggingFaceEncoderModel):
         # during inference in this case
         model_id = self.model_config.adapter_base_model_id or self.model_config.model_id
 
+        executor_backend = "ray" if torch.cuda.device_count() > 1 else "mp"
+
         try:
             model = LLM(
                 model=model_id,
@@ -513,7 +515,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 trust_remote_code=self.benchmark_config.trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
-                distributed_executor_backend="ray",
+                distributed_executor_backend=executor_backend,
                 tensor_parallel_size=torch.cuda.device_count(),
                 disable_custom_all_reduce=True,
                 quantization=quantization,

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -513,7 +513,7 @@ class VLLMModel(HuggingFaceEncoderModel):
                 trust_remote_code=self.benchmark_config.trust_remote_code,
                 revision=self.model_config.revision,
                 seed=4242,
-                distributed_executor_backend="mp",  # "ray",  # TEMP?
+                distributed_executor_backend="ray",  # TEMP?
                 tensor_parallel_size=torch.cuda.device_count(),
                 disable_custom_all_reduce=True,
                 quantization=quantization,


### PR DESCRIPTION
### Fixed
- Use `ray` as distributed executor backend for vLLM if more than one GPU is available,
  which fixes an error when using multiple GPUs with vLLM.

Fixes #652.