### PR TITLE
fix: Do not re-initialise gen models after each dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   evaluation much faster.
 - Use `ray` as distributed executor backend for vLLM if more than one GPU is available,
   which fixes an error when using multiple GPUs with vLLM.
+- Do not re-initialise generative models after each dataset. This both makes evaluation
+  a bit faster as well as avoids an error that occurs when finishing a (model, dataset)
+  evaluation with multiple GPUs. Note that the same error still happens when
+  benchmarking multiple models in the same `scandeval` run when using multiple GPUs, as
+  this is a `ray` issue.
 
 
 ## [v14.0.3] - 2024-12-14

--- a/src/scandeval/benchmark_modules/base.py
+++ b/src/scandeval/benchmark_modules/base.py
@@ -122,7 +122,7 @@ class BenchmarkModule(ABC):
             f"{self.__class__.__name__}."
         )
 
-    @cached_property
+    @property
     def is_generative(self) -> bool:
         """Whether the model is generative.
 
@@ -165,7 +165,7 @@ class BenchmarkModule(ABC):
         """
         ...
 
-    @cached_property
+    @property
     @abstractmethod
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
         """The data collator used to prepare samples during finetuning.
@@ -175,7 +175,7 @@ class BenchmarkModule(ABC):
         """
         ...
 
-    @cached_property
+    @property
     def compute_metrics(self) -> ComputeMetricsFunction:
         """The function used to compute the metrics.
 
@@ -214,7 +214,7 @@ class BenchmarkModule(ABC):
                     f"Unsupported task supertask: {self.dataset_config.task.supertask}."
                 )
 
-    @cached_property
+    @property
     @abstractmethod
     def extract_labels_from_generation(self) -> ExtractLabelsFunction:
         """The function used to extract the labels from the generated output.
@@ -224,7 +224,7 @@ class BenchmarkModule(ABC):
         """
         ...
 
-    @cached_property
+    @property
     @abstractmethod
     def trainer_class(self) -> t.Type["Trainer"]:
         """The Trainer class to use for finetuning.

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -202,7 +202,7 @@ class HuggingFaceEncoderModel(BenchmarkModule):
 
         return model_max_length
 
-    @cached_property
+    @property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
         """The data collator used to prepare samples during finetuning.
 
@@ -221,7 +221,7 @@ class HuggingFaceEncoderModel(BenchmarkModule):
                     f"Unsupported task supertask: {self.dataset_config.task.supertask}."
                 )
 
-    @cached_property
+    @property
     def extract_labels_from_generation(self) -> ExtractLabelsFunction:
         """The function used to extract the labels from the generated output.
 
@@ -233,7 +233,7 @@ class HuggingFaceEncoderModel(BenchmarkModule):
             "for Hugging Face Encoder models."
         )
 
-    @cached_property
+    @property
     def trainer_class(self) -> t.Type["Trainer"]:
         """The Trainer class to use for finetuning.
 

--- a/src/scandeval/benchmark_modules/litellm.py
+++ b/src/scandeval/benchmark_modules/litellm.py
@@ -396,7 +396,7 @@ class LiteLLMModel(BenchmarkModule):
 
         return -1
 
-    @cached_property
+    @property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
         """The data collator used to prepare samples during finetuning.
 
@@ -407,7 +407,7 @@ class LiteLLMModel(BenchmarkModule):
             "The `data_collator` property has not been implemented for LiteLLM models."
         )
 
-    @cached_property
+    @property
     def extract_labels_from_generation(self) -> ExtractLabelsFunction:
         """The function used to extract the labels from the generated output.
 
@@ -434,7 +434,7 @@ class LiteLLMModel(BenchmarkModule):
                     f"Unsupported task supertask: {self.dataset_config.task.supertask}."
                 )
 
-    @cached_property
+    @property
     def trainer_class(self) -> t.Type["Trainer"]:
         """The Trainer class to use for finetuning.
 

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -8,7 +8,7 @@ import logging
 import random
 import sys
 import typing as t
-from functools import cached_property, partial
+from functools import partial
 from pathlib import Path
 from time import sleep
 from types import MethodType
@@ -128,7 +128,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         self._log_metadata()
 
-    @cached_property
+    @property
     def extract_labels_from_generation(self) -> ExtractLabelsFunction:
         """The function used to extract the labels from the generated output.
 
@@ -844,7 +844,7 @@ class VLLMModel(HuggingFaceEncoderModel):
 
         return examples
 
-    @cached_property
+    @property
     def data_collator(self) -> c.Callable[[list[t.Any]], dict[str, t.Any]]:
         """The data collator used to prepare samples during finetuning.
 
@@ -855,7 +855,7 @@ class VLLMModel(HuggingFaceEncoderModel):
             "The `data_collator` property has not been implemented for vLLM models."
         )
 
-    @cached_property
+    @property
     def trainer_class(self) -> t.Type["Trainer"]:
         """The Trainer class to use for finetuning.
 

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -411,6 +411,11 @@ class Benchmarker:
                 # customised to specific datasets
                 if model_config.task in GENERATIVE_MODEL_TASKS:
                     if loaded_model is None:
+                        initial_logging(
+                            model_config=model_config,
+                            dataset_config=dataset_config,
+                            benchmark_config=benchmark_config,
+                        )
                         logger.info("Loading model...")
                         loaded_model = load_model(
                             model_config=model_config,
@@ -537,21 +542,11 @@ class Benchmarker:
         Returns:
             The benchmark result, or an error if the benchmark was unsuccessful.
         """
-        # Initial logging
-        logger.info(
-            f"Benchmarking {model_config.model_id} on {dataset_config.pretty_name}"
-        )
-        if dataset_config.unofficial:
-            logger.info(
-                f"Note that the {dataset_config.name!r} dataset is unofficial, "
-                "meaning that the resulting evaluation will not be included in the "
-                "official leaderboard."
-            )
-        if benchmark_config.debug:
-            logger.info(
-                "Running in debug mode. This will output additional information, as "
-                "well as store the model outputs in the current directory after each "
-                "batch. For this reason, evaluation will be slower."
+        if model is not None:
+            initial_logging(
+                model_config=model_config,
+                dataset_config=dataset_config,
+                benchmark_config=benchmark_config,
             )
 
         while True:
@@ -746,3 +741,33 @@ def prepare_dataset_configs(dataset_names: list[str]) -> list["DatasetConfig"]:
     return [
         cfg for cfg in get_all_dataset_configs().values() if cfg.name in dataset_names
     ]
+
+
+def initial_logging(
+    model_config: "ModelConfig",
+    dataset_config: "DatasetConfig",
+    benchmark_config: "BenchmarkConfig",
+) -> None:
+    """Initial logging at the start of the benchmarking process.
+
+    Args:
+        model_config:
+            The configuration of the model we are evaluating.
+        dataset_config:
+            The configuration of the dataset we are evaluating on.
+        benchmark_config:
+            The general benchmark configuration.
+    """
+    logger.info(f"Benchmarking {model_config.model_id} on {dataset_config.pretty_name}")
+    if dataset_config.unofficial:
+        logger.info(
+            f"Note that the {dataset_config.name!r} dataset is unofficial, "
+            "meaning that the resulting evaluation will not be included in the "
+            "official leaderboard."
+        )
+    if benchmark_config.debug:
+        logger.info(
+            "Running in debug mode. This will output additional information, as "
+            "well as store the model outputs in the current directory after each "
+            "batch. For this reason, evaluation will be slower."
+        )

--- a/src/scandeval/data_models.py
+++ b/src/scandeval/data_models.py
@@ -463,6 +463,6 @@ class HFModelInfo:
             if the model is not an adapter model.
     """
 
-    pipeline_tag: str
+    pipeline_tag: t.Literal["fill-mask", "text-generation"]
     tags: list[str]
     adapter_base_model_id: str | None

--- a/src/scandeval/data_models.py
+++ b/src/scandeval/data_models.py
@@ -463,6 +463,6 @@ class HFModelInfo:
             if the model is not an adapter model.
     """
 
-    pipeline_tag: t.Literal["fill-mask", "text-generation"]
+    pipeline_tag: str
     tags: list[str]
     adapter_base_model_id: str | None


### PR DESCRIPTION
### Fixed
- Do not re-initialise generative models after each dataset. This both makes evaluation
  a bit faster as well as avoids an error that occurs when finishing a (model, dataset)
  evaluation with multiple GPUs. Note that the same error still happens when
  benchmarking multiple models in the same `scandeval` run when using multiple GPUs, as
  this is a `ray` issue.