### PR TITLE
fix: Apply label mapping to labels in few-shot prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- The labels were not displayed correctly in the few-shot examples for base generative
+  models, when benchmarking text classification tasks, which negatively affected scores
+  of the linguistic acceptability task, and to a lesser extent the sentiment
+  classification task. This has been fixed now.
 
 
 ## [v14.1.1] - 2025-01-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The labels were not displayed correctly in the few-shot examples for base generative
   models, when benchmarking text classification tasks, which negatively affected scores
   of the linguistic acceptability task, and to a lesser extent the sentiment
-  classification task. This has been fixed now.
+  classification task. This has been fixed now. The models benchmarked from v14.0.0 are
+  affected and should be re-benchmarked.
 
 
 ## [v14.1.1] - 2025-01-06

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -588,14 +588,18 @@ class VLLMModel(HuggingFaceEncoderModel):
                 A pair (prompt, label), where "label" is an empty string if the model is
                 not instruction tuned (as in this case it is included in the prompt).
             """
+            label_key = "label" if "label" in kwargs else "target_text"
+            label = kwargs.pop(label_key)
+            assert (
+                label is not None
+            ), f"Found a None label for the prompt: {kwargs}. This should not happen."
+            label_mapping = self.dataset_config.prompt_label_mapping
+            label = label_mapping.get(label, label)
             if self.buffer["instruction_model"]:
-                label_key = "label" if "label" in kwargs else "target_text"
-                label = kwargs.pop(label_key)
-                label_mapping = self.dataset_config.prompt_label_mapping
-                label = label_mapping.get(label, label)
                 prompt = self.dataset_config.instruction_prompt.format(**kwargs)
                 return prompt, label
             else:
+                kwargs[label_key] = label
                 return self.dataset_config.prompt_template.format(**kwargs), ""
 
         match task.supertask:


### PR DESCRIPTION
### Fixed
- The labels were not displayed correctly in the few-shot examples for base generative
  models, when benchmarking text classification tasks, which negatively affected scores
  of the linguistic acceptability task, and to a lesser extent the sentiment
  classification task. This has been fixed now.