### PR TITLE
feat: Now use the architectures HF Config param to identify gen models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Changed
+- We now use the `model_type` parameter in the Hugging Face model configuration to
+  determine whether a model is generative or not, as this is more reliable than the
+  previous method of checking the model repository's tags. The downside of this is that
+  the model config must be downloaded, but the overhead is minor.
 
 
 ## [v14.1.2] - 2025-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- We now use the `model_type` parameter in the Hugging Face model configuration to
+- We now use the `architectures` parameter in the Hugging Face model configuration to
   determine whether a model is generative or not, as this is more reliable than the
   previous method of checking the model repository's tags. The downside of this is that
   the model config must be downloaded, but the overhead is minor.

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -30,7 +30,7 @@ from transformers import (
     PreTrainedTokenizer,
     Trainer,
 )
-from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+from transformers.modelcard import TASK_MAPPING
 from urllib3.exceptions import RequestError
 
 from ..constants import DUMMY_FILL_VALUE, GENERATIVE_MODEL_TASKS
@@ -717,11 +717,13 @@ def get_model_repo_info(
             trust_remote_code=benchmark_config.trust_remote_code,
             run_with_cli=benchmark_config.run_with_cli,
         )
-        model_type = hf_config.model_type
-        generative_model_types = [
-            mtype for mtype, _ in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.items()
+        class_names = hf_config.architectures
+        generative_class_names = [
+            class_name
+            for model_task in GENERATIVE_MODEL_TASKS
+            for class_name in TASK_MAPPING[model_task].values()
         ]
-        if model_type in generative_model_types:
+        if any(class_name in generative_class_names for class_name in class_names):
             pipeline_tag = "text-generation"
         else:
             pipeline_tag = "fill-mask"

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -30,9 +30,10 @@ from transformers import (
     PreTrainedTokenizer,
     Trainer,
 )
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 from urllib3.exceptions import RequestError
 
-from ..constants import DUMMY_FILL_VALUE, GENERATIVE_MODEL_TASKS, GENERATIVE_TAGS
+from ..constants import DUMMY_FILL_VALUE, GENERATIVE_MODEL_TASKS
 from ..data_models import BenchmarkConfig, DatasetConfig, HFModelInfo, ModelConfig, Task
 from ..enums import BatchingPreference, Framework, ModelType
 from ..exceptions import (
@@ -703,7 +704,24 @@ def get_model_repo_info(
 
     pipeline_tag = model_info.pipeline_tag
     if pipeline_tag is None:
-        if any(tag in GENERATIVE_TAGS for tag in tags):
+        hf_config = load_hf_model_config(
+            model_id=model_id,
+            num_labels=0,
+            id2label=dict(),
+            label2id=dict(),
+            revision=revision,
+            model_cache_dir=create_model_cache_dir(
+                cache_dir=benchmark_config.cache_dir, model_id=model_id
+            ),
+            api_key=benchmark_config.api_key,
+            trust_remote_code=benchmark_config.trust_remote_code,
+            run_with_cli=benchmark_config.run_with_cli,
+        )
+        model_type = hf_config.model_type
+        generative_model_types = [
+            mtype for mtype, _ in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.items()
+        ]
+        if model_type in generative_model_types:
             pipeline_tag = "text-generation"
         else:
             pipeline_tag = "fill-mask"

--- a/src/scandeval/constants.py
+++ b/src/scandeval/constants.py
@@ -4,7 +4,7 @@
 DUMMY_FILL_VALUE = 100
 
 
-GENERATIVE_MODEL_TASKS = ["text-generation", "conversational", "text2text-generation"]
+GENERATIVE_MODEL_TASKS = ["text-generation", "text2text-generation"]
 
 
 GENERATIVE_DATASET_TASKS = [

--- a/src/scandeval/constants.py
+++ b/src/scandeval/constants.py
@@ -26,16 +26,4 @@ SUPERTASKS_USING_LOGPROBS = ["sequence-classification"]
 METRIC_ATTRIBUTES_TAKING_UP_MEMORY = ["cached_bertscorer"]
 
 
-GENERATIVE_TAGS = [
-    "trl",
-    "mistral",
-    "text-generation-inference",
-    "unsloth",
-    "text-generation",
-    "gemma",
-    "gemma2",
-    "llama",
-]
-
-
 MAX_LOGPROBS = 10

--- a/src/scandeval/model_config.py
+++ b/src/scandeval/model_config.py
@@ -1,6 +1,7 @@
 """Functions related to getting the model configuration."""
 
 import importlib.util
+import logging
 import typing as t
 
 from . import benchmark_modules
@@ -9,6 +10,9 @@ from .exceptions import InvalidModel, NeedsEnvironmentVariable, NeedsExtraInstal
 
 if t.TYPE_CHECKING:
     from .data_models import BenchmarkConfig, ModelConfig
+
+
+logger = logging.getLogger("scandeval")
 
 
 def get_model_config(
@@ -48,6 +52,10 @@ def get_model_config(
         elif isinstance(exists_or_err, NeedsEnvironmentVariable):
             needs_env_vars.append(exists_or_err.env_var)
         elif exists_or_err is True:
+            logger.debug(
+                f"The model {model_id!r} was identified by the "
+                f"{benchmark_module.__name__} benchmark module."
+            )
             model_config = benchmark_module.get_model_config(
                 model_id=model_id, benchmark_config=benchmark_config
             )


### PR DESCRIPTION
### Changed
- We now use the `architectures` parameter in the Hugging Face model configuration to
  determine whether a model is generative or not, as this is more reliable than the
  previous method of checking the model repository's tags. The downside of this is that
  the model config must be downloaded, but the overhead is minor.