### PR TITLE
Fix/mc clf postprocessing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/src/scandeval/task_utils/multiple_choice_classification.py
+++ b/src/scandeval/task_utils/multiple_choice_classification.py
@@ -137,8 +137,8 @@ def postprocess_predictions_and_labels(
         pred_label_dict[example["id"]].append((pred_arr[1], example["label"]))
 
     # Compute the final predictions and labels
+    breakpoint()
     for id_ in set(dataset["id"]):
-        breakpoint()
         preds, labels = zip(*pred_label_dict[id_])
         prediction: str = mapping[np.argmax(preds).item()]
         label: str = mapping[np.argmax(labels).item()]

--- a/src/scandeval/task_utils/multiple_choice_classification.py
+++ b/src/scandeval/task_utils/multiple_choice_classification.py
@@ -109,9 +109,7 @@ def prepare_examples(
         int(choice.startswith(f"{letter}. ") and letter == examples["label"][0])
         for letter, choice in zip("abcde", choices)
     ]
-    new_examples["id"] = [
-        hashlib.md5(string=(doc + "\n".join(choices)).encode()).hexdigest()
-    ] * len(choices)
+    new_examples["id"] = [hashlib.md5(string=doc.encode()).hexdigest()] * len(choices)
     return new_examples
 
 
@@ -141,14 +139,23 @@ def postprocess_predictions_and_labels(
     # Compute the final predictions and labels
     for id_ in set(dataset["id"]):
         preds, labels = zip(*pred_label_dict[id_])
-        try:
-            prediction: str = mapping[np.argmax(preds).item()]
-        except KeyError as e:
-            logger.error(f"KeyError: {e}")
-            breakpoint()
-            pass
-        label: str = mapping[np.argmax(labels).item()]
-        all_predictions.append(prediction)
-        all_labels.append(label)
+
+        # Some IDs appear multiple times in the dataset, since we are bootstrapping.
+        # Here we separate them into their respective groups.
+        assert (
+            len(labels) % sum(labels) == 0
+        ), "The number of labels is not divisible by the sum of the labels."
+        group_size = len(labels) // sum(labels)
+        preds_groups = [
+            preds[i : i + group_size] for i in range(0, len(preds), group_size)
+        ]
+        labels_groups = [
+            labels[i : i + group_size] for i in range(0, len(labels), group_size)
+        ]
+        for preds_group, labels_group in zip(preds_groups, labels_groups):
+            prediction: str = mapping[np.argmax(preds_group).item()]
+            label: str = mapping[np.argmax(labels_group).item()]
+            all_predictions.append(prediction)
+            all_labels.append(label)
 
     return all_predictions, all_labels

--- a/src/scandeval/task_utils/multiple_choice_classification.py
+++ b/src/scandeval/task_utils/multiple_choice_classification.py
@@ -137,10 +137,14 @@ def postprocess_predictions_and_labels(
         pred_label_dict[example["id"]].append((pred_arr[1], example["label"]))
 
     # Compute the final predictions and labels
-    breakpoint()
     for id_ in set(dataset["id"]):
         preds, labels = zip(*pred_label_dict[id_])
-        prediction: str = mapping[np.argmax(preds).item()]
+        try:
+            prediction: str = mapping[np.argmax(preds).item()]
+        except KeyError as e:
+            logger.error(f"KeyError: {e}")
+            breakpoint()
+            pass
         label: str = mapping[np.argmax(labels).item()]
         all_predictions.append(prediction)
         all_labels.append(label)

--- a/src/scandeval/task_utils/multiple_choice_classification.py
+++ b/src/scandeval/task_utils/multiple_choice_classification.py
@@ -109,7 +109,9 @@ def prepare_examples(
         int(choice.startswith(f"{letter}. ") and letter == examples["label"][0])
         for letter, choice in zip("abcde", choices)
     ]
-    new_examples["id"] = [hashlib.md5(string=doc.encode()).hexdigest()] * len(choices)
+    new_examples["id"] = [
+        hashlib.md5(string=(doc + "\n".join(choices)).encode()).hexdigest()
+    ] * len(choices)
     return new_examples
 
 

--- a/src/scandeval/task_utils/multiple_choice_classification.py
+++ b/src/scandeval/task_utils/multiple_choice_classification.py
@@ -138,6 +138,7 @@ def postprocess_predictions_and_labels(
 
     # Compute the final predictions and labels
     for id_ in set(dataset["id"]):
+        breakpoint()
         preds, labels = zip(*pred_label_dict[id_])
         prediction: str = mapping[np.argmax(preds).item()]
         label: str = mapping[np.argmax(labels).item()]


### PR DESCRIPTION
When postprocessing encoder predictions on multiple choice classification tasks, we need to take duplicates into account due to bootstrapping. I.e., there will be samples with the same ID. We deal with that in this PR.