### PR TITLE
Use trust_remote_code arguments and re-initialise corrupted model cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
-
+### Fixed
+- The `trust_remote_code` argument was not supplied when loading the Hugging Face
+  configuration in some places, which caused an unnecessary dialogue with the user when
+  evaluating models. This correctly now uses the `--trust-remote-code` argument as
+  supplied by the user.
 
 
 ## [v14.2.0] - 2025-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   configuration in some places, which caused an unnecessary dialogue with the user when
   evaluating models. This correctly now uses the `--trust-remote-code` argument as
   supplied by the user.
+- If the model cache is corrupted, we now log this and re-initialise it, rather than
+  raising an error.
 
 
 ## [v14.2.0] - 2025-01-11

--- a/src/scandeval/benchmark_modules/fresh.py
+++ b/src/scandeval/benchmark_modules/fresh.py
@@ -190,6 +190,7 @@ class FreshEncoderModel(HuggingFaceEncoderModel):
             id2label=self.dataset_config.id2label,
             label2id=self.dataset_config.label2id,
             cache_dir=self.model_config.model_cache_dir,
+            trust_remote_code=self.benchmark_config.trust_remote_code,
         )
         model = model_cls(config)
 
@@ -211,6 +212,7 @@ class FreshEncoderModel(HuggingFaceEncoderModel):
                 cache_dir=self.model_config.model_cache_dir,
                 use_fast=True,
                 verbose=False,
+                trust_remote_code=self.benchmark_config.trust_remote_code,
             )
         except (JSONDecodeError, OSError):
             raise InvalidModel(f"Could not load tokenizer for model {real_model_id!r}.")

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -793,6 +793,7 @@ def load_model_and_tokenizer(
             revision=model_config.revision,
             cache_dir=model_config.model_cache_dir,
             token=token,
+            trust_remote_code=benchmark_config.trust_remote_code,
         )
     except ValueError as e:
         raise InvalidModel(
@@ -941,6 +942,7 @@ def load_tokenizer(
         revision=revision,
         cache_dir=model_cache_dir,
         token=token,
+        trust_remote_code=trust_remote_code,
     )
     num_retries = 5
     for _ in range(num_retries):

--- a/src/scandeval/human_evaluation.py
+++ b/src/scandeval/human_evaluation.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import click
 from datasets import Dataset
-from transformers import AutoTokenizer
 
 from .benchmark_config_factory import build_benchmark_config
 from .benchmarker import BenchmarkResult
@@ -612,15 +611,7 @@ class HumanEvaluator:
 
     def compute_and_log_scores(self) -> None:
         """Computes and logs the scores for the dataset."""
-        tokenizer = AutoTokenizer.from_pretrained(self.dummy_model_id)
-        tokenizer.pad_token = tokenizer.eos_token
-        sequences = tokenizer(
-            self.active_dataset["answer"],
-            add_special_tokens=False,
-            padding=True,
-            return_tensors="pt",
-        ).input_ids
-        model_output = GenerativeModelOutput(sequences=sequences)
+        model_output = GenerativeModelOutput(sequences=self.active_dataset["answer"])
 
         active_dataset_dict = self.active_dataset.to_dict()
         assert isinstance(active_dataset_dict, dict)

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -59,8 +59,17 @@ class ModelCache:
             with self.cache_path.open("w") as f:
                 json.dump(dict(), f)
 
-        with self.cache_path.open() as f:
-            json_cache = json.load(f)
+        try:
+            with self.cache_path.open() as f:
+                json_cache = json.load(f)
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Failed to load the cache from {self.cache_path}. The cache will be "
+                f"re-initialised."
+            )
+            json_cache = dict()
+            with self.cache_path.open("w") as f:
+                json.dump(dict(), f)
 
         cache: dict[str, SingleGenerativeModelOutput] = dict()
         for key in json_cache:

--- a/src/scandeval/speed_benchmark.py
+++ b/src/scandeval/speed_benchmark.py
@@ -60,7 +60,7 @@ def benchmark_speed_single_iteration(
     Returns:
         A dictionary containing the scores for the current iteration.
     """
-    gpt2_tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    gpt2_tokenizer = AutoTokenizer.from_pretrained("gpt2", trust_remote_code=True)
 
     base_doc = "Document which contains roughly 10 tokens. "
     multiplier = 10 * (1 + itr_idx)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,7 +131,9 @@ def test_should_prefix_space_be_added_to_labels(model_id, expected, auth):
 )
 def test_get_end_of_chat_token_ids(model_id, expected_token_ids, expected_string, auth):
     """Test ability to get the chat token IDs of a model."""
-    tokenizer = AutoTokenizer.from_pretrained(model_id, token=auth)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_id, token=auth, trust_remote_code=True
+    )
     end_of_chat_token_ids = get_end_of_chat_token_ids(tokenizer=tokenizer)
     assert end_of_chat_token_ids == expected_token_ids
     if expected_string is not None:


### PR DESCRIPTION
### Fixed
- The `trust_remote_code` argument was not supplied when loading the Hugging Face
  configuration in some places, which caused an unnecessary dialogue with the user when
  evaluating models. This correctly now uses the `--trust-remote-code` argument as
  supplied by the user.
- If the model cache is corrupted, we now log this and re-initialise it, rather than
  raising an error.