### PR TITLE
Fix/index error for encoders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      # - id: debug-statements
+      - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: debug-statements
+      # - id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   is the default backend for ScandEval.
 - Now correctly displays a message to the user when access to a model is contingent on
   approval from the repository authors, rather than raising an error.
+- Fixed issue while determining the maximal sequence length of encoder models on CUDA
+  devices, which caused an error when evaluating some models. We now move the model to
+  CPU temporarily to determine the maximal sequence length.
 
 
 ## [v14.2.0] - 2025-01-11

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1065,6 +1065,8 @@ def align_model_and_tokenizer(
     else:
         tokenizer.model_max_length = 512
 
+    # Move the model to the CPU, since otherwise we can't catch the IndexErrors when
+    # finding the maximum sequence length of the model
     model_device = model.device
     model.to(torch.device("cpu"))
 
@@ -1088,6 +1090,7 @@ def align_model_and_tokenizer(
             except IndexError:
                 continue
 
+    # Move the model back to the original device
     model.to(model_device)
 
     # If there is a mismatch between the vocab size according to the tokenizer and

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1081,7 +1081,6 @@ def align_model_and_tokenizer(
         )
         with torch.inference_mode():
             try:
-                breakpoint()
                 model(dummy_inputs, attention_mask=torch.ones_like(dummy_inputs))
                 break
 

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1083,7 +1083,7 @@ def align_model_and_tokenizer(
                 break
 
             # This happens if `max_length` is too large
-            except IndexError:
+            except (IndexError, RuntimeError):
                 continue
 
     # If there is a mismatch between the vocab size according to the tokenizer and

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1085,7 +1085,7 @@ def align_model_and_tokenizer(
                 break
 
             # This happens if `max_length` is too large
-            except (IndexError, RuntimeError):
+            except IndexError:
                 continue
 
     model.to(model_device)

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1078,6 +1078,7 @@ def align_model_and_tokenizer(
         )
         with torch.inference_mode():
             try:
+                breakpoint()
                 model(dummy_inputs, attention_mask=torch.ones_like(dummy_inputs))
                 break
 

--- a/src/scandeval/benchmark_modules/hf.py
+++ b/src/scandeval/benchmark_modules/hf.py
@@ -1065,6 +1065,9 @@ def align_model_and_tokenizer(
     else:
         tokenizer.model_max_length = 512
 
+    model_device = model.device
+    model.to(torch.device("cpu"))
+
     # Manually check that this model max length is valid for the model, and adjust
     # otherwise
     initial_max_length = tokenizer.model_max_length
@@ -1085,6 +1088,8 @@ def align_model_and_tokenizer(
             # This happens if `max_length` is too large
             except (IndexError, RuntimeError):
                 continue
+
+    model.to(model_device)
 
     # If there is a mismatch between the vocab size according to the tokenizer and
     # the vocab size according to the model, we raise an error


### PR DESCRIPTION
### Fixed
- Fixed issue while determining the maximal sequence length of encoder models on CUDA
  devices, which caused an error when evaluating some models. We now move the model to
  CPU temporarily to determine the maximal sequence length.