### PR TITLE
Fix/danske talemaader prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and the rest (580) for testing.
 - Changed the prompting of Danske Talemåder dataset slightly, to only use the word
   "expression" (da. "udtryk") in the prompt, rather than mention idiom (da. "talemåde")
-  directly. This did not affect the performance significantly, however.
+  directly.
 
 ### Fixed
 - Better error message when trying to benchmark a non-generative model on a generative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed the Belebele splits, as there were too few training splits for evaluation on
   encoder models to make sense. We now use 256 samples for training, 64 for validation
   and the rest (580) for testing.
+- Changed the prompting of Danske Talemåder dataset slightly, to only use the word
+  "expression" (da. "udtryk") in the prompt, rather than mention idiom (da. "talemåde")
+  directly. This did not affect the performance significantly, however.
 
 ### Fixed
 - Better error message when trying to benchmark a non-generative model on a generative

--- a/docs/datasets/danish.md
+++ b/docs/datasets/danish.md
@@ -372,19 +372,19 @@ Here are a few examples from the training split:
 
 ```json
 {
-  "text": "tale nogen efter munden\nSvarmuligheder:\na. være føjelig og give nogen ret selvom man ikke nødvendigvis er enig\nb. erklære sig helt enig med en anden person\nc. sige det præcis samme som en anden; efterabe\nd. være egoistisk og snæversynet; kun tænke på sig selv",
+  "text": "Hvad betyder udtrykket 'tale nogen efter munden'?\nSvarmuligheder:\na. være føjelig og give nogen ret selvom man ikke nødvendigvis er enig\nb. erklære sig helt enig med en anden person\nc. sige det præcis samme som en anden; efterabe\nd. være egoistisk og snæversynet; kun tænke på sig selv",
   "label": "a"
 }
 ```
 ```json
 {
-  "text": "der falder en sten fra éns hjerte\nSvarmuligheder:\na. en bestemt (kriminel, eftersøgt) person er forsvundet\nb. man bliver fri for en sorg eller bekymring; man bliver lettet\nc. man mister én man har kær\nd. en sten forlader et hjerte man er i besiddelse af",
+  "text": "Hvad betyder udtrykket 'der falder en sten fra éns hjerte'?\nSvarmuligheder:\na. en bestemt (kriminel, eftersøgt) person er forsvundet\nb. man bliver fri for en sorg eller bekymring; man bliver lettet\nc. man mister én man har kær\nd. en sten forlader et hjerte man er i besiddelse af",
   "label": "b"
 }
 ```
 ```json
 {
-  "text": "have spidse albuer\nSvarmuligheder:\na. person der har det meget dårligt fysisk og psykisk\nb. have ophobet vrede over længere tid\nc. hævde sig på andres bekostning\nd. have knogler der træder tydeligt frem på ens albuer",
+  "text": "Hvad betyder udtrykket 'have spidse albuer'?\nSvarmuligheder:\na. person der har det meget dårligt fysisk og psykisk\nb. have ophobet vrede over længere tid\nc. hævde sig på andres bekostning\nd. have knogler der træder tydeligt frem på ens albuer",
   "label": "c"
 }
 ```

--- a/src/scandeval/benchmarker.py
+++ b/src/scandeval/benchmarker.py
@@ -744,15 +744,18 @@ def initial_logging(
         benchmark_config:
             The general benchmark configuration.
     """
-    logger.info(f"Benchmarking {model_config.model_id} on {dataset_config.pretty_name}")
-    
-    # Log evaluation split and type
     split_type = "validation" if not benchmark_config.evaluate_test_split else "test"
-    logger.info(f"Evaluating on {split_type} split")
-
-    if model_config.is_generative:
-        eval_type = "few-shot" if benchmark_config.few_shot else "zero-shot"
-        logger.info(f"Using {eval_type} evaluation for generative model")
+    if model_config.task in GENERATIVE_MODEL_TASKS:
+        if benchmark_config.few_shot:
+            eval_type = "Few-shot benchmarking"
+        else:
+            eval_type = "Zero-shot benchmarking"
+    else:
+        eval_type = "Benchmarking"
+    logger.info(
+        f"{eval_type} {model_config.model_id} on the {split_type} of "
+        f"{dataset_config.pretty_name}"
+    )
 
     if dataset_config.unofficial:
         logger.info(

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -1345,10 +1345,10 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     languages=[DA],
     labels=["a", "b", "c", "d"],
     prompt_prefix="Følgende er multiple choice spørgsmål (med svar).",
-    prompt_template="Hvad er betydningen af følgende talemåde: {text}\nSvar: {label}",
+    prompt_template="{text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="Hvad er betydningen af følgende talemåde: {text}\n\nBesvar "
-    "ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd'.",
+    instruction_prompt="{text}\n\nBesvar ovenstående spørgsmål ved at svare med "
+    "'a', 'b', 'c' eller 'd'.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )

--- a/src/scripts/create_danske_talemaader.py
+++ b/src/scripts/create_danske_talemaader.py
@@ -45,7 +45,9 @@ def main() -> None:
     # Set up the data as a dataframe
     df = pd.merge(left=no_labels_df, right=only_labels_df)
     df["text"] = [
-        row.talemaade_udtryk.replace("\n", " ").strip() + "\n"
+        "Hvad betyder udtrykket '"
+        + row.talemaade_udtryk.replace("\n", " ").strip()
+        + "'?\n"
         "Svarmuligheder:\n"
         "a. " + row.A.replace("\n", " ").strip() + "\n"
         "b. " + row.B.replace("\n", " ").strip() + "\n"


### PR DESCRIPTION
### Changed
- Changed the prompting of Danske Talemåder dataset slightly, to only use the word
  "expression" (da. "udtryk") in the prompt, rather than mention idiom (da. "talemåde")
  directly. This did not affect the performance significantly, however.