### PR TITLE
Multiple-choice prompting and corrupt model cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,6 @@ jobs:
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: uv sync --no-dev --extra test
@@ -62,9 +59,6 @@ jobs:
 
       - name: Install uv and set up Python
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
 
       - name: Install Dependencies
         run: uv sync --no-dev --extra test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   context and a question. This has been fixed now.
 - Fixed an issue when generative models in gated repos caused an error message when both
   of the environment variables `HUGGINGFACE_API_KEY` and `HF_TOKEN` were not set.
+- Sometimes the generative model cache becomes corrupt and cannot be stored to disk.
+  Rather than raising an error we now reset the model cache and carry on.
 
 
 ## [v14.3.0] - 2025-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed the prompting of Danske Talemåder dataset slightly, to only use the word
   "expression" (da. "udtryk") in the prompt, rather than mention idiom (da. "talemåde")
   directly.
+- Changed the instruction prompts to multiple choice tasks by specifying that only 'a',
+  'b', 'c' or 'd' should be used. This caused a mix-up with Claude models, since they do
+  not support logprobs.
 
 ### Fixed
 - Better error message when trying to benchmark a non-generative model on a generative

--- a/docs/datasets/danish.md
+++ b/docs/datasets/danish.md
@@ -416,7 +416,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd'.
+  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd', og intet andet.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -482,7 +482,7 @@ When evaluating generative models, we use the following setup (see the
   b. {option_b}
   c. {option_c}
 
-  Besvar ovenstående spørgsmål ved at svare med 'a', 'b' eller 'c'.
+  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd', og intet andet.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -554,7 +554,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd'.
+  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd', og intet andet.
   ```
 
 
@@ -618,7 +618,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd'.
+  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd', og intet andet.
   ```
 
 
@@ -683,7 +683,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd'.
+  Besvar ovenstående spørgsmål ved at svare med 'a', 'b', 'c' eller 'd', og intet andet.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/dutch.md
+++ b/docs/datasets/dutch.md
@@ -446,7 +446,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd'.
+  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd', en niets anders.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -516,7 +516,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd'.
+  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd', en niets anders.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -587,7 +587,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd'.
+  Beantwoord de bovenstaande vraag met 'a', 'b', 'c' of 'd', en niets anders.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/english.md
+++ b/docs/datasets/english.md
@@ -357,7 +357,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Answer the above question by replying with 'a', 'b', 'c' or 'd'.
+  Answer the above question by replying with 'a', 'b', 'c' or 'd', and nothing else.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -425,7 +425,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Answer the above question by replying with 'a', 'b', 'c' or 'd'.
+  Answer the above question by replying with 'a', 'b', 'c' or 'd', and nothing else.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -494,7 +494,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Answer the above question by replying with 'a', 'b', 'c' or 'd'.
+  Answer the above question by replying with 'a', 'b', 'c' or 'd', and nothing else.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/french.md
+++ b/docs/datasets/french.md
@@ -360,7 +360,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd'.
+  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd', et rien d'autre.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -431,7 +431,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd'.
+  Répondez à la question ci-dessus par 'a', 'b', 'c' ou 'd', et rien d'autre.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/german.md
+++ b/docs/datasets/german.md
@@ -343,7 +343,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd'.
+  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -407,7 +407,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd'.
+  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -473,7 +473,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd'.
+  Beantworten Sie die obige Frage mit 'a', 'b', 'c' oder 'd', und nichts anderes.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/icelandic.md
+++ b/docs/datasets/icelandic.md
@@ -549,7 +549,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd'.
+  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -620,7 +620,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd'.
+  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -691,7 +691,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd'.
+  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -760,7 +760,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd'.
+  Svaraðu eftirfarandi spurningum með 'a', 'b', 'c' eða 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/norwegian.md
+++ b/docs/datasets/norwegian.md
@@ -584,7 +584,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd'.
+  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -654,7 +654,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd'.
+  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -725,7 +725,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd'.
+  Besvar følgende spørsmål med 'a', 'b', 'c' eller 'd', og engu öðru.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/docs/datasets/swedish.md
+++ b/docs/datasets/swedish.md
@@ -354,7 +354,7 @@ When evaluating generative models, we use the following setup (see the
   ```
   Fråga: {text}
 
-  Besvara följande fråga med 'a', 'b', 'c' eller 'd'.
+  Besvara följande fråga med 'a', 'b', 'c' eller 'd', och inget annat.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -424,7 +424,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvara följande fråga med 'a', 'b', 'c' eller 'd'.
+  Besvara följande fråga med 'a', 'b', 'c' eller 'd', och inget annat.
   ```
 
 You can evaluate this dataset directly as follows:
@@ -495,7 +495,7 @@ When evaluating generative models, we use the following setup (see the
   c. {option_c}
   d. {option_d}
 
-  Besvara följande fråga med 'a', 'b', 'c' eller 'd'.
+  Besvara följande fråga med 'a', 'b', 'c' eller 'd', och inget annat.
   ```
 
 You can evaluate this dataset directly as follows:

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -1347,8 +1347,8 @@ DANSKE_TALEMAADER_CONFIG = DatasetConfig(
     prompt_prefix="Følgende er multiple choice spørgsmål (med svar).",
     prompt_template="{text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBesvar ovenstående spørgsmål ved at svare med "
-    "'a', 'b', 'c' eller 'd'.",
+    instruction_prompt="Spørgsmål: {text}\n\nBesvar ovenstående spørgsmål ved at "
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1364,7 +1364,7 @@ DANISH_CITIZEN_TESTS_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørgsmål: {text}\n\nBesvar ovenstående spørgsmål ved at "
-    "svare med 'a', 'b', 'c' eller 'd'.",
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1381,7 +1381,7 @@ MMLU_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørsmål: {text}\n\nBesvar følgende spørsmål med 'a', 'b', "
-    "'c' eller 'd'.",
+    "'c' eller 'd', og ikke noe annet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1398,7 +1398,7 @@ MMLU_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Fråga: {text}\n\nBesvara följande fråga med 'a', 'b', 'c' "
-    "eller 'd'.",
+    "eller 'd', och inget annat.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1415,7 +1415,7 @@ MMLU_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spurningar: {text}\n\nSvaraðu eftirfarandi spurningum með 'a', "
-    "'b', 'c' eða 'd'.",
+    "'b', 'c' eða 'd', og engu öðru.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1433,7 +1433,7 @@ MMLU_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Frage: {text}\n\nBeantworten Sie die obige Frage mit 'a', 'b', "
-    "'c' oder 'd'.",
+    "'c' oder 'd', und nichts anderes.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1450,7 +1450,7 @@ MMLU_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Vraag: {text}\n\nBeantwoord de bovenstaande vraag met 'a', 'b', "
-    "'c' of 'd'.",
+    "'c' of 'd', en niets anders.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1465,8 +1465,8 @@ MMLU_CONFIG = DatasetConfig(
     prompt_prefix="The following are multiple choice questions (with answers).",
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="Question: {text}\n\nAnswer the above question by "
-    "replying with 'a', 'b', 'c' or 'd'.",
+    instruction_prompt="Question: {text}\n\nAnswer the above question by replying "
+    "with 'a', 'b', 'c' or 'd', and nothing else.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1483,7 +1483,7 @@ MMLU_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørgsmål: {text}\n\nBesvar ovenstående spørgsmål ved at "
-    "svare med 'a', 'b', 'c' eller 'd'.",
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1502,7 +1502,7 @@ MMLU_FR_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nRéponse: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Question: {text}\n\nRépondez à la question ci-dessus par 'a', "
-    "'b', 'c' ou 'd'.",
+    "'b', 'c' ou 'd', et rien d'autre.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1519,7 +1519,7 @@ ARC_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørgsmål: {text}\n\nBesvar ovenstående spørgsmål ved at "
-    "svare med 'a', 'b', 'c' eller 'd'.",
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1537,7 +1537,7 @@ ARC_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørsmål: {text}\n\nBesvar følgende spørsmål med 'a', 'b', "
-    "'c' eller 'd'.",
+    "'c' eller 'd', og ikke noe annet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1555,7 +1555,7 @@ ARC_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Fråga: {text}\n\nBesvara följande fråga med 'a', 'b', 'c' "
-    "eller 'd'.",
+    "eller 'd', och inget annat.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1573,7 +1573,7 @@ ARC_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spurningar: {text}\n\nSvaraðu eftirfarandi spurningum með 'a', "
-    "'b', 'c' eða 'd'.",
+    "'b', 'c' eða 'd', og engu öðru.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1590,7 +1590,7 @@ ARC_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Frage: {text}\n\nBeantworten Sie die obige Frage mit 'a', 'b', "
-    "'c' oder 'd'.",
+    "'c' oder 'd', und nichts anderes.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1607,8 +1607,8 @@ ARC_NL_CONFIG = DatasetConfig(
     prompt_prefix="Hieronder staan meerkeuzevragen (met antwoorden).",
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="Vraag: {text}\n\nBeantwoord de bovenstaande vraag met 'a', "
-    "'b', 'c' of 'd'.",
+    instruction_prompt="Vraag: {text}\n\nBeantwoord de bovenstaande vraag met 'a', 'b', "
+    "'c' of 'd', en niets anders.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1624,8 +1624,8 @@ ARC_CONFIG = DatasetConfig(
     prompt_prefix="The following are multiple choice questions (with answers).",
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="Question: {text}\n\nAnswer the above question by "
-    "replying with 'a', 'b', 'c' or 'd'.",
+    instruction_prompt="Question: {text}\n\nAnswer the above question by replying "
+    "with 'a', 'b', 'c' or 'd', and nothing else.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1648,7 +1648,7 @@ HELLASWAG_DA_CONFIG = DatasetConfig(
     prompt_template="Spørgsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørgsmål: {text}\n\nBesvar ovenstående spørgsmål ved at "
-    "svare med 'a', 'b', 'c' eller 'd'.",
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1665,7 +1665,7 @@ HELLASWAG_NO_CONFIG = DatasetConfig(
     prompt_template="Spørsmål: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spørsmål: {text}\n\nBesvar følgende spørsmål med 'a', 'b', "
-    "'c' eller 'd'.",
+    "'c' eller 'd', og ikke noe annet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1682,7 +1682,7 @@ HELLASWAG_SV_CONFIG = DatasetConfig(
     prompt_template="Fråga: {text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Fråga: {text}\n\nBesvara följande fråga med 'a', 'b', 'c' "
-    "eller 'd'.",
+    "eller 'd', och inget annat.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1699,7 +1699,7 @@ HELLASWAG_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spurningar: {text}\n\nSvaraðu eftirfarandi spurningum með 'a', "
-    "'b', 'c' eða 'd'.",
+    "'b', 'c' eða 'd', og engu öðru.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1717,7 +1717,7 @@ WINOGRANDE_IS_CONFIG = DatasetConfig(
     prompt_template="Spurningar: {text}\nSvara: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Spurningar: {text}\n\nSvaraðu eftirfarandi spurningum með 'a', "
-    "'b', 'c' eða 'd'.",
+    "'b', 'c' eða 'd', og engu öðru.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1734,7 +1734,7 @@ HELLASWAG_DE_CONFIG = DatasetConfig(
     prompt_template="Frage: {text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Frage: {text}\n\nBeantworten Sie die obige Frage mit 'a', 'b', "
-    "'c' oder 'd'.",
+    "'c' oder 'd', und nichts anderes.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1751,7 +1751,7 @@ HELLASWAG_NL_CONFIG = DatasetConfig(
     prompt_template="Vraag: {text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Vraag: {text}\n\nBeantwoord de bovenstaande vraag met 'a', 'b', "
-    "'c' of 'd'.",
+    "'c' of 'd', en niets anders.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1767,8 +1767,8 @@ HELLASWAG_CONFIG = DatasetConfig(
     prompt_prefix="The following are multiple choice questions (with answers).",
     prompt_template="Question: {text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="Question: {text}\n\nAnswer the above question by "
-    "replying with 'a', 'b', 'c' or 'd'.",
+    instruction_prompt="Question: {text}\n\nAnswer the above question by replying "
+    "with 'a', 'b', 'c' or 'd', and nothing else.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1786,7 +1786,7 @@ HELLASWAG_FR_CONFIG = DatasetConfig(
     prompt_template="Question: {text}\nRéponse: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     instruction_prompt="Question: {text}\n\nRépondez à la question ci-dessus par 'a', "
-    "'b', 'c' ou 'd'.",
+    "'b', 'c' ou 'd', et rien d'autre.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1808,8 +1808,8 @@ BELEBELE_DA_CONFIG = DatasetConfig(
     "svar.",
     prompt_template="{text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBesvar ovenstående spørgsmål ved at svare med 'a', "
-    "'b', 'c' eller 'd'.",
+    instruction_prompt="{text}\n\nBesvar ovenstående spørgsmål ved at "
+    "svare med 'a', 'b', 'c' eller 'd', og intet andet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1827,7 +1827,8 @@ BELEBELE_SV_CONFIG = DatasetConfig(
     "svar.",
     prompt_template="{text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBesvara följande fråga med 'a', 'b', 'c' eller 'd'.",
+    instruction_prompt="{text}\n\nBesvara följande fråga med 'a', 'b', 'c' "
+    "eller 'd', och inget annat.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1844,8 +1845,8 @@ BELEBELE_NO_CONFIG = DatasetConfig(
     prompt_prefix="Her følger tekster med tilhørende multiple choice spørsmål og svar.",
     prompt_template="{text}\nSvar: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBesvar følgende spørsmål med 'a', 'b', 'c' eller "
-    "'d'.",
+    instruction_prompt="{text}\n\nBesvar følgende spørsmål med 'a', 'b', "
+    "'c' eller 'd', og ikke noe annet.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1862,8 +1863,8 @@ BELEBELE_IS_CONFIG = DatasetConfig(
     prompt_prefix="Eftirfarandi eru textar með tilheyrandi fjölvalsspurningum og "
     "svörum.",
     prompt_template="{text}\nSvara: {label}",
-    instruction_prompt="{text}\n\nSvaraðu eftirfarandi spurningum með 'a', 'b', 'c' "
-    "eða 'd'.",
+    instruction_prompt="{text}\n\nSvaraðu eftirfarandi spurningum með 'a', "
+    "'b', 'c' eða 'd', og engu öðru.",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
     num_few_shot_examples=5,
     max_generated_tokens=5,
@@ -1882,8 +1883,8 @@ BELEBELE_DE_CONFIG = DatasetConfig(
     "und Antworten.",
     prompt_template="{text}\nAntwort: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBeantworten Sie die obige Frage mit 'a', 'b', 'c' "
-    "oder 'd'.",
+    instruction_prompt="{text}\n\nBeantworten Sie die obige Frage mit 'a', 'b', "
+    "'c' oder 'd', und nichts anderes.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1901,8 +1902,8 @@ BELEBELE_NL_CONFIG = DatasetConfig(
     "antwoorden.",
     prompt_template="{text}\nAntwoord: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nBeantwoord de bovenstaande vraag met 'a', 'b', 'c' "
-    "of 'd'.",
+    instruction_prompt="{text}\n\nBeantwoord de bovenstaande vraag met 'a', 'b', "
+    "'c' of 'd', en niets anders.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,
@@ -1920,8 +1921,8 @@ BELEBELE_FR_CONFIG = DatasetConfig(
     "multiples et de réponses.",
     prompt_template="{text}\nRéponse: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nRépondez à la question ci-dessus par 'a', 'b', 'c' "
-    "ou 'd'.",
+    instruction_prompt="{text}\n\nRépondez à la question ci-dessus par 'a', "
+    "'b', 'c' ou 'd', et rien d'autre.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
 )
@@ -1937,8 +1938,8 @@ BELEBELE_CONFIG = DatasetConfig(
     "and answers.",
     prompt_template="{text}\nAnswer: {label}",
     prompt_label_mapping=dict(a="a", b="b", c="c", d="d"),
-    instruction_prompt="{text}\n\nAnswer the above question by replying with 'a', "
-    "'b', 'c' or 'd'.",
+    instruction_prompt="{text}\n\nAnswer the above question by replying "
+    "with 'a', 'b', 'c' or 'd', and nothing else.",
     num_few_shot_examples=5,
     max_generated_tokens=5,
     unofficial=True,

--- a/src/scandeval/model_cache.py
+++ b/src/scandeval/model_cache.py
@@ -83,8 +83,17 @@ class ModelCache:
         for key, value in self.cache.items():
             dumpable_cache[key] = asdict(value)
 
-        with self.cache_path.open("w") as f:
-            json.dump(dumpable_cache, f)
+        try:
+            with self.cache_path.open("w") as f:
+                json.dump(dumpable_cache, f)
+        except KeyError:
+            logger.warning(
+                f"Failed to load the cache from {self.cache_path}. The cache will be "
+                f"re-initialised."
+            )
+            self.cache = dict()
+            with self.cache_path.open("w") as f:
+                json.dump(dict(), f)
 
     def _hash_key(self, key: str | list[dict[str, str]]) -> str:
         """Hash the key to use as an index in the cache.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 from transformers import AutoTokenizer
 
+from scandeval.benchmark_modules.hf import load_hf_model_config
 from scandeval.utils import (
     enforce_reproducibility,
     get_end_of_chat_token_ids,
@@ -86,7 +87,18 @@ def test_module_is_installed(module_name, expected):
 )
 def test_should_prompts_be_stripped(model_id, expected, auth):
     """Test that a model ID is a generative model."""
-    tokenizer = AutoTokenizer.from_pretrained(model_id, token=auth)
+    config = load_hf_model_config(
+        model_id=model_id,
+        num_labels=0,
+        id2label=dict(),
+        label2id=dict(),
+        revision="main",
+        model_cache_dir=None,
+        api_key=auth,
+        trust_remote_code=True,
+        run_with_cli=True,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_id, config=config)
     labels = ["positiv", "negativ"]
     strip_prompts = should_prompts_be_stripped(
         labels_to_be_generated=labels, tokenizer=tokenizer
@@ -105,7 +117,18 @@ def test_should_prompts_be_stripped(model_id, expected, auth):
 )
 def test_should_prefix_space_be_added_to_labels(model_id, expected, auth):
     """Test that a model ID is a generative model."""
-    tokenizer = AutoTokenizer.from_pretrained(model_id, token=auth)
+    config = load_hf_model_config(
+        model_id=model_id,
+        num_labels=0,
+        id2label=dict(),
+        label2id=dict(),
+        revision="main",
+        model_cache_dir=None,
+        api_key=auth,
+        trust_remote_code=True,
+        run_with_cli=True,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_id, config=config)
     labels = ["positiv", "negativ"]
     strip_prompts = should_prefix_space_be_added_to_labels(
         labels_to_be_generated=labels, tokenizer=tokenizer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,7 +110,7 @@ def test_should_prompts_be_stripped(model_id, expected, auth):
     argnames=["model_id", "expected"],
     argvalues=[
         ("mistralai/Mistral-7B-v0.1", False),
-        ("meta-llama/Meta-Llama-3-8B", False),
+        ("meta-llama/Meta-Llama-3-8B", True),
         ("AI-Sweden-Models/gpt-sw3-6.7b-v2", False),
         ("01-ai/Yi-6B", True),
     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,6 +78,8 @@ def test_module_is_installed(module_name, expected):
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
     argvalues=[
+        ("mistralai/Mistral-7B-v0.1", True),
+        ("meta-llama/Meta-Llama-3-8B", True),
         ("AI-Sweden-Models/gpt-sw3-6.7b-v2", True),
         ("01-ai/Yi-6B", True),
         ("google-bert/bert-base-uncased", False),
@@ -106,7 +108,12 @@ def test_should_prompts_be_stripped(model_id, expected, auth):
 
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
-    argvalues=[("AI-Sweden-Models/gpt-sw3-6.7b-v2", False), ("01-ai/Yi-6B", True)],
+    argvalues=[
+        ("mistralai/Mistral-7B-v0.1", False),
+        ("meta-llama/Meta-Llama-3-8B", True),
+        ("AI-Sweden-Models/gpt-sw3-6.7b-v2", False),
+        ("01-ai/Yi-6B", True),
+    ],
 )
 def test_should_prefix_space_be_added_to_labels(model_id, expected, auth):
     """Test whether a prefix space should be added to labels."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,8 +78,6 @@ def test_module_is_installed(module_name, expected):
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
     argvalues=[
-        ("mistralai/Mistral-7B-v0.1", True),
-        ("meta-llama/Meta-Llama-3-8B", True),
         ("AI-Sweden-Models/gpt-sw3-6.7b-v2", True),
         ("01-ai/Yi-6B", True),
         ("google-bert/bert-base-uncased", False),
@@ -108,27 +106,11 @@ def test_should_prompts_be_stripped(model_id, expected, auth):
 
 @pytest.mark.parametrize(
     argnames=["model_id", "expected"],
-    argvalues=[
-        ("mistralai/Mistral-7B-v0.1", False),
-        ("meta-llama/Meta-Llama-3-8B", True),
-        ("AI-Sweden-Models/gpt-sw3-6.7b-v2", False),
-        ("01-ai/Yi-6B", True),
-    ],
+    argvalues=[("AI-Sweden-Models/gpt-sw3-6.7b-v2", False), ("01-ai/Yi-6B", True)],
 )
 def test_should_prefix_space_be_added_to_labels(model_id, expected, auth):
-    """Test that a model ID is a generative model."""
-    config = load_hf_model_config(
-        model_id=model_id,
-        num_labels=0,
-        id2label=dict(),
-        label2id=dict(),
-        revision="main",
-        model_cache_dir=None,
-        api_key=auth,
-        trust_remote_code=True,
-        run_with_cli=True,
-    )
-    tokenizer = AutoTokenizer.from_pretrained(model_id, config=config)
+    """Test whether a prefix space should be added to labels."""
+    tokenizer = AutoTokenizer.from_pretrained(model_id, token=auth)
     labels = ["positiv", "negativ"]
     strip_prompts = should_prefix_space_be_added_to_labels(
         labels_to_be_generated=labels, tokenizer=tokenizer


### PR DESCRIPTION
### Changed
- Changed the instruction prompts to multiple choice tasks by specifying that only 'a', 'b', 'c' or 'd' should be used. This caused a mix-up with Claude models, since they do not support logprobs.

### Fixed
- Sometimes the generative model cache becomes corrupt and cannot be stored to disk. Rather than raising an error we now reset the model cache and carry on.