### PR TITLE
fix: If bos_token is None then ignore it, in `get_end_of_reasoning_token_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Regex mismatch caused the wrong sequence length for GPT-4o models. This has been fixed
   now.
+- A bug occurred when locating a model's end of reasoning token (e.g., `</think>`) if
+the model's tokenizer had no BOS token. This has been fixed now.
 
 
 ## [v15.0.0] - 2025-02-02

--- a/src/scandeval/benchmark_modules/vllm.py
+++ b/src/scandeval/benchmark_modules/vllm.py
@@ -1113,7 +1113,8 @@ def get_end_of_reasoning_token_id(
         .outputs[0]
         .text
     )
-    completion = completion.replace(tokenizer.bos_token, "").strip()
+    if tokenizer.bos_token is not None:
+        completion = completion.replace(tokenizer.bos_token, "").strip()
 
     # If it doesn't contain a reasoning token, we can't find the end of reasoning token
     match = re.search(pattern=r"<\w+>", string=completion)


### PR DESCRIPTION
### Fixed
- A bug occurred when locating a model's end of reasoning token (e.g., `</think>`) if
the model's tokenizer had no BOS token. This has been fixed now.