### PR TITLE
Fix/typos and missing translations for french

### DIFF
--- a/docs/datasets/french.md
+++ b/docs/datasets/french.md
@@ -194,27 +194,27 @@ When evaluating generative models, we use the following setup (see the
 - Number of few-shot examples: 12
 - Prefix prompt:
   ```
-  Følgende er sætninger og om de er grammatisk korrekte.
+  Les phrases suivantes indiquent si elles sont grammaticalement correctes.
   ```
 - Base prompt template:
   ```
-  Sætning: {text}
-  Grammatisk korrekt: {label}
+  Phrase: {text}
+  Correct du point de vue grammatical: {label}
   ```
 - Instruction-tuned prompt template:
   ```
-  Sætning: {text}
+  Phrase: {text}
 
-  Bestem om sætningen er grammatisk korrekt eller ej. Svar med 'ja', hvis sætningen er korrekt, og 'nej', hvis den ikke er.
+  Déterminez si la phrase est grammaticalement correcte ou non. Répondez par 'oui' si la phrase est correcte et par 'non' si elle ne l'est pas, et rien d'autre.
   ```
 - Label mapping:
-    - `correct` ➡️ `ja`
-    - `incorrect` ➡️ `nej`
+    - `correct` ➡️ `oui`
+    - `incorrect` ➡️ `non`
 
 You can evaluate this dataset directly as follows:
 
 ```bash
-$ scandeval --model <model-id> --dataset scala-da
+$ scandeval --model <model-id> --dataset scala-fr
 ```
 
 

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -881,9 +881,9 @@ SCALA_FR_CONFIG = DatasetConfig(
     task=LA,
     languages=[FR],
     labels=["incorrect", "correct"],
-    prompt_prefix="The following are sentences and whether they are grammatically "
-    "correct.",
-    prompt_template="Phrase : {text}\nCorrect du point de vue grammatical : {label}",
+    prompt_prefix="Les phrases suivantes indiquent si elles sont grammaticalement ",
+    "correctes.",
+    prompt_template="Phrase : {text}\nCorrect du point de vue grammatical: {label}",
     prompt_label_mapping=dict(correct="oui", incorrect="non"),
     instruction_prompt="Phrase: {text}\n\nDéterminez si la phrase est grammaticalement "
     "correcte ou non. Répondez par 'oui' si la phrase est correcte et par 'non' si "

--- a/src/scandeval/dataset_configs.py
+++ b/src/scandeval/dataset_configs.py
@@ -1816,7 +1816,7 @@ HELLASWAG_CONFIG = DatasetConfig(
 HELLASWAG_FR_CONFIG = DatasetConfig(
     name="hellaswag-fr",
     pretty_name="the truncated version of the French common-sense reasoning dataset "
-    "HellaSwag-nl, translated from the English HellaSwag dataset",
+    "HellaSwag-fr, translated from the English HellaSwag dataset",
     huggingface_id="ScandEval/hellaswag-fr-mini",
     task=COMMON_SENSE,
     languages=[FR],


### PR DESCRIPTION
This fixes some typos/missing translations i noticed while working on adding support Italian 😄

- Add missing translations to "setup" in docs for scala-fr
- Fix name of hellaswag-fr pretty name
- Add missing translation of prefix prompt to scala-fr